### PR TITLE
[IME] Add IME lowering pipeline for RISC-V matrix extension (int8/fp16 matmul).

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -37,6 +37,32 @@ def _get_buddy_opt_path() -> str:
     return os.path.join(path, "buddy-opt")
 
 
+def _get_buddy_translate_path() -> str:
+    """Path to buddy-translate (from buddy-mlir build)."""
+    path = os.getenv("BUDDY_MLIR_BINARY_DIR", "")
+    if path == "":
+        raise Exception("BUDDY_MLIR_BINARY_DIR is not set.")
+    return os.path.join(path, "buddy-translate")
+
+
+def _get_buddy_llc_path() -> str:
+    """Path to buddy-llc (from buddy-mlir build)."""
+    path = os.getenv("BUDDY_MLIR_BINARY_DIR", "")
+    if path == "":
+        raise Exception("BUDDY_MLIR_BINARY_DIR is not set.")
+    return os.path.join(path, "buddy-llc")
+
+
+def _use_ime_pipeline() -> bool:
+    """Return True when the IME (RISC-V matrix-extension) lowering path should be used.
+
+    Set the environment variable TRITON_RISCV_USE_IME=1 to activate.  The IME
+    pipeline lowers linalg.matmul to ime.vfmadot (fp16) / ime.vmadot (int)
+    instructions via buddy-mlir and cross-compiles to a RISC-V ELF object.
+    """
+    return os.getenv("TRITON_RISCV_USE_IME", "") == "1"
+
+
 def _dump_ir_if_needed(files):
     path = os.getenv("TRITON_SHARED_DUMP_PATH", "")
     if not path:
@@ -100,52 +126,102 @@ def _ttsharedir_to_llir(ttsharedir: str):
         llir_path = os.path.join(tmpdir, "ll.ir")
         Path(ttshared_path).write_text(ttsharedir)
         buddy_opt_path = _get_buddy_opt_path()
-        # TritonShared-MLIR to LLVM-MLIR
-        subprocess.check_call(
-            [
-                buddy_opt_path,
-                ttshared_path,
-                "--convert-linalg-to-affine-loops",
-                # Note: eliminate-empty-tensors fails when there are multiple func.return ops
-                # in a single kernel which are the results of early returns.
-                # See python/examples/test_early_return.py for examples.
-                # We disable this pass for now since performance on CPU isn't the main
-                # focus at the moment.
-                # "--eliminate-empty-tensors",
-                "--empty-tensor-to-alloc-tensor",
-                "--one-shot-bufferize=allow-return-allocs-from-loops=true",
-                "--matmul-vectorization",
-                "--lower-affine",
-                "--convert-linalg-to-loops",
-                "--expand-strided-metadata",
-                "--convert-scf-to-cf",
-                "--convert-arith-to-llvm",
-                "--convert-math-to-llvm",
-                "--convert-complex-to-llvm",
-                "--convert-vector-to-llvm",
-                "--convert-index-to-llvm",
-                "--memref-expand",
-                "--finalize-memref-to-llvm",
-                "--convert-func-to-llvm",
-                "--convert-cf-to-llvm",
-                # Lowering memrefs creates more affine.apply ops.
-                # Lowering these affine ops again creates further arith ops,
-                # so we have to run these two passes again here.
-                "--lower-affine",
-                "--convert-arith-to-llvm",
-                # Remove all unrealized casts created
-                "--reconcile-unrealized-casts",
-                "--mlir-print-debuginfo",
-                "-o",
-                llmlir_path,
-            ]
-        )
 
-        # LLVM-MLIR to LLVM-IR
-        mlir_translate_path = _get_llvm_bin_path("mlir-translate")
-        subprocess.check_call(
-            [mlir_translate_path, llmlir_path, "--mlir-to-llvmir", "-o", llir_path]
-        )
+        if _use_ime_pipeline():
+            # ---------------------------------------------------------------
+            # IME path: Triton-Shared MLIR → buddy-mlir IME dialect → LLVM IR
+            # Lowers linalg.matmul (f16) to ime.vfmadot via buddy-mlir passes,
+            # then cross-compiles to a RISC-V ELF object with +buddyext.
+            # ---------------------------------------------------------------
+            subprocess.check_call(
+                [
+                    buddy_opt_path,
+                    ttshared_path,
+                    # Bufferize tensor ops before IME lowering
+                    "--empty-tensor-to-alloc-tensor",
+                    "--one-shot-bufferize=allow-return-allocs-from-loops=true",
+                    # Lower linalg.matmul (memref) → ime.vfmadot / ime.vmadot
+                    "--lower-linalg-to-ime",
+                    # Lower IME dialect → vector / loop ops
+                    "--lower-ime",
+                    # Lower any remaining linalg / affine / SCF ops
+                    "--convert-linalg-to-loops",
+                    "--lower-affine",
+                    "--expand-strided-metadata",
+                    "--convert-scf-to-cf",
+                    # Lower to LLVM dialect
+                    "--convert-cf-to-llvm",
+                    "--convert-arith-to-llvm",
+                    "--convert-math-to-llvm",
+                    "--convert-complex-to-llvm",
+                    "--convert-vector-to-llvm",
+                    "--convert-index-to-llvm",
+                    "--convert-func-to-llvm",
+                    "--memref-expand",
+                    "--finalize-memref-to-llvm",
+                    # Lowering memrefs creates more affine.apply ops; run again.
+                    "--lower-affine",
+                    "--convert-arith-to-llvm",
+                    "--reconcile-unrealized-casts",
+                    "--mlir-print-debuginfo",
+                    "-o",
+                    llmlir_path,
+                ]
+            )
+            # LLVM-MLIR → LLVM-IR via buddy-translate (handles buddyext dialect)
+            buddy_translate_path = _get_buddy_translate_path()
+            subprocess.check_call(
+                [buddy_translate_path, "--buddy-to-llvmir", llmlir_path, "-o", llir_path]
+            )
+        else:
+            # ---------------------------------------------------------------
+            # Standard path: buddy-mlir vectorisation → host LLVM IR
+            # ---------------------------------------------------------------
+            subprocess.check_call(
+                [
+                    buddy_opt_path,
+                    ttshared_path,
+                    "--convert-linalg-to-affine-loops",
+                    # Note: eliminate-empty-tensors fails when there are multiple func.return ops
+                    # in a single kernel which are the results of early returns.
+                    # See python/examples/test_early_return.py for examples.
+                    # We disable this pass for now since performance on CPU isn't the main
+                    # focus at the moment.
+                    # "--eliminate-empty-tensors",
+                    "--empty-tensor-to-alloc-tensor",
+                    "--one-shot-bufferize=allow-return-allocs-from-loops=true",
+                    "--matmul-vectorization",
+                    "--lower-affine",
+                    "--convert-linalg-to-loops",
+                    "--expand-strided-metadata",
+                    "--convert-scf-to-cf",
+                    "--convert-arith-to-llvm",
+                    "--convert-math-to-llvm",
+                    "--convert-complex-to-llvm",
+                    "--convert-vector-to-llvm",
+                    "--convert-index-to-llvm",
+                    "--memref-expand",
+                    "--finalize-memref-to-llvm",
+                    "--convert-func-to-llvm",
+                    "--convert-cf-to-llvm",
+                    # Lowering memrefs creates more affine.apply ops.
+                    # Lowering these affine ops again creates further arith ops,
+                    # so we have to run these two passes again here.
+                    "--lower-affine",
+                    "--convert-arith-to-llvm",
+                    # Remove all unrealized casts created
+                    "--reconcile-unrealized-casts",
+                    "--mlir-print-debuginfo",
+                    "-o",
+                    llmlir_path,
+                ]
+            )
+            # LLVM-MLIR to LLVM-IR
+            mlir_translate_path = _get_llvm_bin_path("mlir-translate")
+            subprocess.check_call(
+                [mlir_translate_path, llmlir_path, "--mlir-to-llvmir", "-o", llir_path]
+            )
+
         _dump_ir_if_needed([ttshared_path, llmlir_path, llir_path])
         return Path(llir_path).read_text()
 
@@ -210,6 +286,41 @@ def _llir_to_bin(llir: str, metadata):
                 subprocess_args.extend(["-g", "-fsanitize=thread"])
 
             subprocess.check_call(subprocess_args)
+        elif _use_ime_pipeline():
+            # IME path: cross-compile to RISC-V with buddyext (vfmadot / vmadot).
+            # buddy-llc understands the RISC-V IME intrinsics produced by
+            # buddy-translate and generates correct machine code.
+            # On non-RISC-V hosts (e.g. x86_64) the IR contains RVV scalable
+            # vectors that the host llc cannot handle.  Dump is already done;
+            # skip compilation and surface a clean error.
+            if platform.machine() != "riscv64":
+                # buddy-llc is cross-compilation capable (x86 binary → RISC-V ELF),
+                # but the resulting .obj cannot be linked or executed on this host.
+                # Import pytest lazily so this module stays usable outside pytest.
+                try:
+                    import pytest
+                    pytest.skip(
+                        f"IME pipeline requires RISC-V hardware for execution "
+                        f"(current host: {platform.machine()}). "
+                        "Intermediate IR files dumped to TRITON_SHARED_DUMP_PATH (if set)."
+                    )
+                except ImportError:
+                    raise NotImplementedError(
+                        "IME pipeline: Cannot link/run RISC-V scalable-vector IR on "
+                        f"{platform.machine()}. Run on RISC-V hardware."
+                    )
+            buddy_llc_path = _get_buddy_llc_path()
+            llc_args = [
+                buddy_llc_path,
+                src_path,
+                "-filetype=obj",
+                "-mtriple=riscv64",
+                "-mattr=+m,+a,+f,+d,+c,+v,+zfh,+zvfh,+zba,+zbb,+buddyext",
+                "-relocation-model=pic",
+                "-o",
+                dst_path,
+            ]
+            subprocess.check_call(llc_args)
         else:
             llc_path = _get_llvm_bin_path("llc")
             llc_args = [

--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -1182,10 +1182,27 @@ struct MatmulConverter : public OpConversionPattern<triton::DotOp> {
         rewriter.create<linalg::FillOp>(loc, ValueRange{zero}, ValueRange{init})
             .result();
 
-    auto res = rewriter
-                   .create<linalg::MatmulOp>(loc, ValueRange{opa, opb},
-                                             ValueRange{zeroes})
-                   .getResult(0);
+    // For mixed-precision integer matmul (e.g. i8 x i8 -> i32), linalg.matmul
+    // requires a cast attribute so the inner multiply can promote i8 operands
+    // to the i32 accumulator type.  Without it the op verifier rejects the IR.
+    Value res;
+    auto aElemType =
+        cast<RankedTensorType>(opa.getType()).getElementType();
+    bool isMixedIntPrecision = integers && (aElemType != elementType);
+    if (isMixedIntPrecision) {
+      auto castAttr = linalg::TypeFnAttr::get(rewriter.getContext(),
+                                              linalg::TypeFn::cast_signed);
+      res = rewriter
+                .create<linalg::MatmulOp>(loc, TypeRange{zeroes.getType()},
+                                          ValueRange{opa, opb},
+                                          ValueRange{zeroes}, castAttr)
+                .getResult(0);
+    } else {
+      res = rewriter
+                .create<linalg::MatmulOp>(loc, ValueRange{opa, opb},
+                                          ValueRange{zeroes})
+                .getResult(0);
+    }
 
     if (!skipC) {
       if (integers) {

--- a/python/examples/test_matmul_fp16.py
+++ b/python/examples/test_matmul_fp16.py
@@ -1,0 +1,142 @@
+import torch
+
+import triton
+import triton.language as tl
+import benchmark
+
+
+@triton.jit
+def matmul_fp16_kernel(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # Strides
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """FP16 matmul kernel: C = A x B  (all fp16, accumulate in fp16)."""
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    # Accumulate in fp16 (matches IME vfmadot behaviour).
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float16)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        accumulator += tl.dot(a, b, out_dtype=tl.float16)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    c = accumulator.to(tl.float16)
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def matmul_fp16(a, b):
+    """Wrapper: checks shapes, allocates output, launches fp16 kernel."""
+    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+    assert a.is_contiguous(), "Matrix A must be contiguous"
+    assert b.is_contiguous(), "Matrix B must be contiguous"
+    assert a.dtype == torch.float16 and b.dtype == torch.float16
+
+    M, K = a.shape
+    K, N = b.shape
+    c = torch.empty((M, N), device=a.device, dtype=torch.float16)
+
+    def grid(META):
+        return (
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        )
+
+    matmul_fp16_kernel[grid](
+        a, b, c,
+        M, N, K,
+        a.stride(0), a.stride(1),
+        b.stride(0), b.stride(1),
+        c.stride(0), c.stride(1),
+        # Block sizes aligned with IME fp16 tile: 4x4x4
+        BLOCK_SIZE_M=4,
+        BLOCK_SIZE_N=4,
+        BLOCK_SIZE_K=4,
+        GROUP_SIZE_M=8,
+    )
+    return c
+
+
+def test_matmul_fp16(device="cpu"):
+    torch.manual_seed(42)
+    M, K, N = 16, 16, 16
+    a = torch.randn((M, K), device=device, dtype=torch.float16)
+    b = torch.randn((K, N), device=device, dtype=torch.float16)
+
+    triton_output = matmul_fp16(a, b)
+    # Reference: use float32 for torch.matmul then cast back
+    torch_output = torch.matmul(a.float(), b.float()).half()
+
+    # fp16 arithmetic is lossy; use a generous tolerance
+    torch.testing.assert_close(triton_output, torch_output, atol=1e-1, rtol=1e-2)
+    print(f"test_matmul_fp16 PASSED  (M={M}, K={K}, N={N})")
+
+
+def test_matmul_fp16_boundary(device="cpu"):
+    """Non-aligned dimensions to exercise the boundary-handling lowering path."""
+    torch.manual_seed(7)
+    M, K, N = 7, 6, 5
+    a = torch.randn((M, K), device=device, dtype=torch.float16)
+    b = torch.randn((K, N), device=device, dtype=torch.float16)
+
+    triton_output = matmul_fp16(a, b)
+    torch_output = torch.matmul(a.float(), b.float()).half()
+
+    torch.testing.assert_close(triton_output, torch_output, atol=1e-1, rtol=1e-2)
+    print(f"test_matmul_fp16_boundary PASSED  (M={M}, K={K}, N={N})")
+
+
+@benchmark.measure()
+def bench_matmul_fp16(M, N, K, provider):
+    a = torch.randn((M, K), device="cpu", dtype=torch.float16)
+    b = torch.randn((K, N), device="cpu", dtype=torch.float16)
+    if provider == "torch":
+        torch.matmul(a, b)
+    if provider == "triton":
+        matmul_fp16(a, b)
+
+
+if __name__ == "__main__":
+    benchmark.select_cpu_backend()
+    test_matmul_fp16()
+    test_matmul_fp16_boundary()
+    for X in [16 * i for i in range(1, 6)]:
+        for provider in ["torch", "triton"]:
+            bench_matmul_fp16(X, X, X, provider)

--- a/python/examples/test_matmul_int8.py
+++ b/python/examples/test_matmul_int8.py
@@ -1,0 +1,150 @@
+import torch
+import numpy as np
+
+import triton
+import triton.language as tl
+import benchmark
+
+
+@triton.jit
+def matmul_int8_kernel(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # Strides
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Int8 matmul kernel: C (i32) = A (i8) x B (i8).
+
+    Accumulates in int32 to avoid overflow, matching the IME vmadot
+    instruction's widening-multiply-accumulate semantics.
+    """
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    # Accumulate in int32 (matches IME vmadot widening MAC behaviour).
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.int32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0)
+        accumulator += tl.dot(a, b, out_dtype=tl.int32)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    c = accumulator  # already int32
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def matmul_int8(a, b):
+    """Wrapper: checks shapes, allocates int32 output, launches int8 kernel."""
+    assert a.shape[1] == b.shape[0], "Incompatible dimensions"
+    assert a.is_contiguous(), "Matrix A must be contiguous"
+    assert b.is_contiguous(), "Matrix B must be contiguous"
+    assert a.dtype == torch.int8 and b.dtype == torch.int8
+
+    M, K = a.shape
+    K, N = b.shape
+    # Output is int32 (widening accumulation)
+    c = torch.zeros((M, N), device=a.device, dtype=torch.int32)
+
+    def grid(META):
+        return (
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        )
+
+    matmul_int8_kernel[grid](
+        a, b, c,
+        M, N, K,
+        a.stride(0), a.stride(1),
+        b.stride(0), b.stride(1),
+        c.stride(0), c.stride(1),
+        # Block sizes aligned with IME int8 tile: TILE_M=4, TILE_K=8, TILE_N=4
+        BLOCK_SIZE_M=4,
+        BLOCK_SIZE_N=4,
+        BLOCK_SIZE_K=8,
+        GROUP_SIZE_M=8,
+    )
+    return c
+
+
+def test_matmul_int8(device="cpu"):
+    torch.manual_seed(42)
+    M, K, N = 16, 16, 16
+    # Use small values to avoid int8 overflow in the reference matmul
+    a = torch.randint(-16, 16, (M, K), dtype=torch.int8, device=device)
+    b = torch.randint(-16, 16, (K, N), dtype=torch.int8, device=device)
+
+    triton_output = matmul_int8(a, b)
+
+    # Reference: numpy int32 matmul (torch.matmul doesn't support i8 on CPU)
+    a_np = a.numpy().astype(np.int32)
+    b_np = b.numpy().astype(np.int32)
+    torch_output = torch.from_numpy(a_np @ b_np)
+
+    torch.testing.assert_close(triton_output, torch_output, atol=0, rtol=0)
+    print(f"test_matmul_int8 PASSED  (M={M}, K={K}, N={N})")
+
+
+def test_matmul_int8_boundary(device="cpu"):
+    """Non-aligned dimensions to exercise boundary-handling lowering path."""
+    torch.manual_seed(7)
+    M, K, N = 7, 9, 5   # K=9 is not a multiple of BLOCK_SIZE_K=8
+    a = torch.randint(-8, 8, (M, K), dtype=torch.int8, device=device)
+    b = torch.randint(-8, 8, (K, N), dtype=torch.int8, device=device)
+
+    triton_output = matmul_int8(a, b)
+    a_np = a.numpy().astype(np.int32)
+    b_np = b.numpy().astype(np.int32)
+    torch_output = torch.from_numpy(a_np @ b_np)
+
+    torch.testing.assert_close(triton_output, torch_output, atol=0, rtol=0)
+    print(f"test_matmul_int8_boundary PASSED  (M={M}, K={K}, N={N})")
+
+
+@benchmark.measure()
+def bench_matmul_int8(M, N, K, provider):
+    a = torch.randint(-16, 16, (M, K), dtype=torch.int8, device="cpu")
+    b = torch.randint(-16, 16, (K, N), dtype=torch.int8, device="cpu")
+    if provider == "triton":
+        matmul_int8(a, b)
+
+
+if __name__ == "__main__":
+    benchmark.select_cpu_backend()
+    test_matmul_int8()
+    test_matmul_int8_boundary()
+    for X in [16 * i for i in range(1, 6)]:
+        bench_matmul_int8(X, X, X, "triton")


### PR DESCRIPTION
## Summary
Add a dedicated compilation path for RISC‑V IME (Integral Matrix Extension), enabling Triton tt.dot (fp16/int8) to lower to ime.vfmadot / ime.vmadot via buddy‑mlir. The existing host‑CPU vectorization path remains unchanged and default.

## Changes
`backend/compiler.py`:
- New helpers: _get_buddy_translate_path(), _get_buddy_llc_path(), _use_ime_pipeline() (checks TRITON_RISCV_USE_IME=1).
- _ttsharedir_to_llir(): IME path skips --matmul-vectorization, runs --lower-linalg-to-ime → --lower-ime → LLVM passes → buddy-translate --buddy-to-llvmir.
- _llir_to_bin(): IME path uses buddy-llc with -mtriple=riscv64 -mattr=+m,+a,+f,+d,+c,+v,+zfh,+zvfh,+zba,+zbb,+buddyext; on non‑RISC‑V hosts the test is skipped with a clear message (IR dumps are still saved).

`include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp`: 

- Fix mixed‑precision integer matmul (i8×i8→i32): attach cast = cast_signed to linalg.matmul when input and output element types differ; required for int8 IME pipeline.

**New test files (python/examples/)**: 
- test_matmul_fp16.py: aligned (16×16×16) and boundary (7×6×5) tests; tolerance atol=0.1, rtol=1e-2.
- test_matmul_int8.py: aligned (16×16×16) and boundary (7×9×5) tests; exact match.

## Testing
```bash
cd /path/to/triton
source .venv/bin/activate

BUILD_DIR=$(ls -d build/cmake.linux-*-cpython-*)
export TRITON_SHARED_OPT_PATH=$(pwd)/${BUILD_DIR}/third_party/triton_shared/tools/triton-shared-opt/triton-shared-opt
export BUDDY_MLIR_BINARY_DIR=/path/to/buddy-mlir/build/bin
export LLVM_BINARY_DIR=/path/to/buddy-mlir/llvm/build/bin
export TRITON_RISCV_USE_IME=1
rm -rf ~/.triton/cache

pytest ../triton-riscv/python/examples/test_matmul_fp16.py -v
pytest ../triton-riscv/python/examples/test_matmul_int8.py -v
```

On x86_64: tests are skipped with a message (IR files are still dumped if TRITON_SHARED_DUMP_PATH is set).
On RISC‑V hardware (RVV + Zvfh + IME): tests run and verify numerical correctness.

## Compatibility
Without TRITON_RISCV_USE_IME=1 the code follows the original path exactly; no behavior change for existing users.