### PR TITLE
[task] Migrate and validate silu_and_mul and gelu_and_mul kernels

### DIFF
--- a/python/examples/flaggems/gelu_and_mul.py
+++ b/python/examples/flaggems/gelu_and_mul.py
@@ -1,0 +1,185 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def gelu_none_and_mul_kernel(
+    x_ptr,
+    y_ptr,
+    output_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+
+    x_fp32 = x.to(tl.float32)
+    RCP_SQRT_2: tl.constexpr = 0.7071067811
+    x_gelu = 0.5 * x_fp32 * (1 + tl.erf(x_fp32 * RCP_SQRT_2))
+    result = x_gelu * y
+
+    tl.store(output_ptr + offsets, result, mask=mask)
+
+
+@triton.jit
+def gelu_none_and_mul_grad_kernel(
+    x_ptr,
+    y_ptr,
+    dgrad_ptr,
+    dx_ptr,
+    dy_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    dgrad = tl.load(dgrad_ptr + offsets, mask=mask)
+
+    RCP_SQRT_2: tl.constexpr = 0.7071067811
+    COEFF: tl.constexpr = 0.7978845608028654
+
+    x_fp32 = x.to(tl.float32)
+    x_gelu = 0.5 * x_fp32 * (1 + tl.erf(x_fp32 * RCP_SQRT_2))
+
+    d_gelu = dgrad * y
+    dx = (
+        d_gelu
+        * 0.5
+        * (
+            1.0
+            + tl.erf(x_fp32 * RCP_SQRT_2)
+            + x_fp32 * COEFF * tl.exp(-0.5 * x_fp32 * x_fp32)
+        )
+    )
+    dy = dgrad * x_gelu
+
+    tl.store(dx_ptr + offsets, dx, mask=mask)
+    tl.store(dy_ptr + offsets, dy, mask=mask)
+
+
+@triton.jit
+def gelu_tanh_and_mul_kernel(
+    x_ptr,
+    y_ptr,
+    output_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+
+    x_fp32 = x.to(tl.float32)
+    tanh_arg = x_fp32 * 0.79788456 * (1.0 + 0.044715 * (x_fp32 * x_fp32))
+    exp2x = tl.exp(2.0 * tanh_arg)
+    tanh_val = (exp2x - 1.0) / (exp2x + 1.0)
+
+    x_gelu = 0.5 * x_fp32 * (1.0 + tanh_val)
+    result = x_gelu * y
+
+    tl.store(output_ptr + offsets, result, mask=mask)
+
+
+@triton.jit
+def gelu_tanh_and_mul_grad_kernel(
+    x_ptr,
+    y_ptr,
+    dgrad_ptr,
+    dx_ptr,
+    dy_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    dgrad = tl.load(dgrad_ptr + offsets, mask=mask)
+
+    x_fp32 = x.to(tl.float32)
+    y_fp32 = y.to(tl.float32)
+
+    sqrt_2_over_pi = 0.7978845608028654  # sqrt(2 / pi)
+    a_cubed = x_fp32 * x_fp32 * x_fp32
+    tanh_arg = sqrt_2_over_pi * (x_fp32 + 0.044715 * a_cubed)
+    exp2x = tl.exp(2.0 * tanh_arg)
+    tanh_result = (exp2x - 1.0) / (exp2x + 1.0)
+    geglu_a = 0.5 * x_fp32 * (1 + tanh_result)
+    dy = geglu_a * dgrad
+
+    term1 = 0.5 * (1 + tanh_result)
+    tanh_sq = tanh_result * tanh_result
+    term2 = (
+        0.5
+        * x_fp32
+        * (1 - tanh_sq)
+        * (sqrt_2_over_pi * (1 + 3 * 0.044715 * x_fp32 * x_fp32))
+    )
+    dx = dgrad * y_fp32 * (term1 + term2)
+
+    tl.store(dx_ptr + offsets, dx, mask=mask)
+    tl.store(dy_ptr + offsets, dy, mask=mask)
+
+
+class GeluAndMul(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, y, approximate="none"):
+        ctx.save_for_backward(x, y)
+        ctx.approximate = approximate
+        output = torch.empty_like(x)
+        n_elements = x.numel()
+        BLOCK_SIZE = 64
+        grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+
+        if approximate == "none":
+            gelu_none_and_mul_kernel[grid](
+                x, y, output, n_elements, BLOCK_SIZE=BLOCK_SIZE
+            )
+        elif approximate == "tanh":
+            gelu_tanh_and_mul_kernel[grid](
+                x, y, output, n_elements, BLOCK_SIZE=BLOCK_SIZE
+            )
+        else:
+            raise ValueError(f"Invalid approximate value: {approximate}")
+        return output
+
+    @staticmethod
+    def backward(ctx, dgrad):
+        x, y = ctx.saved_tensors
+        dx = torch.empty_like(x)
+        dy = torch.empty_like(y)
+        n_elements = x.numel()
+        BLOCK_SIZE = 64
+        grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+
+        if ctx.approximate == "none":
+            gelu_none_and_mul_grad_kernel[grid](
+                x, y, dgrad, dx, dy, n_elements, BLOCK_SIZE=BLOCK_SIZE
+            )
+        else:
+            gelu_tanh_and_mul_grad_kernel[grid](
+                x, y, dgrad, dx, dy, n_elements, BLOCK_SIZE=BLOCK_SIZE
+            )
+        return dx, dy, None
+
+
+def gelu_and_mul(x, y, approximate="none"):
+    return GeluAndMul.apply(x, y, approximate)

--- a/python/examples/flaggems/silu_and_mul.py
+++ b/python/examples/flaggems/silu_and_mul.py
@@ -1,0 +1,101 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def silu_and_mul_kernel(
+    x_ptr,
+    y_ptr,
+    output_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+
+    x_fp32 = x.to(tl.float32)
+    x_silu = tl.fdiv(x_fp32, (1.0 + tl.exp(-x_fp32)))
+    result = x_silu * y
+
+    tl.store(output_ptr + offsets, result, mask=mask)
+
+
+@triton.jit
+def silu_and_mul_grad_kernel(
+    x_ptr,
+    y_ptr,
+    dgrad_ptr,
+    dx_ptr,
+    dy_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    dgrad = tl.load(dgrad_ptr + offsets, mask=mask)
+
+    x_fp32 = x.to(tl.float32)
+    sig = 1 / (1 + tl.exp(-x_fp32))
+    x_silu = x_fp32 * sig
+    d_x_silu = sig * (1 + x_fp32 * (1 - sig))
+    dx = d_x_silu * dgrad * y
+    dy = dgrad * x_silu
+
+    tl.store(dx_ptr + offsets, dx, mask=mask)
+    tl.store(dy_ptr + offsets, dy, mask=mask)
+
+
+class SiluAndMul(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, A, B):
+        ctx.save_for_backward(A, B)
+        output = torch.empty_like(A)
+        n_elements = A.numel()
+        BLOCK_SIZE = 64
+        grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+        silu_and_mul_kernel[grid](
+            A, B, output, n_elements, BLOCK_SIZE=BLOCK_SIZE
+        )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        A, B = ctx.saved_tensors
+        grad_A = torch.empty_like(A)
+        grad_B = torch.empty_like(B)
+        n_elements = A.numel()
+        BLOCK_SIZE = 64
+        grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+        silu_and_mul_grad_kernel[grid](
+            A,
+            B,
+            grad_output,
+            grad_A,
+            grad_B,
+            n_elements,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+        return grad_A, grad_B
+
+
+def silu_and_mul(A, B):
+    return SiluAndMul.apply(A, B)
+
+
+def silu_and_mul_out(A, B, out):
+    n_element = A.numel()
+    BLOCK_SIZE = 64
+    grid = (triton.cdiv(n_element, BLOCK_SIZE),)
+    silu_and_mul_kernel[grid](A, B, out, n_element, BLOCK_SIZE=BLOCK_SIZE)
+    return out

--- a/python/examples/flaggems/test_fused_ops.py
+++ b/python/examples/flaggems/test_fused_ops.py
@@ -1,0 +1,169 @@
+import pytest
+import torch
+import triton
+
+from .gelu_and_mul import (
+    gelu_and_mul,
+    gelu_none_and_mul_grad_kernel,
+    gelu_none_and_mul_kernel,
+    gelu_tanh_and_mul_grad_kernel,
+    gelu_tanh_and_mul_kernel,
+)
+from .silu_and_mul import (
+    silu_and_mul,
+    silu_and_mul_grad_kernel,
+    silu_and_mul_kernel,
+    silu_and_mul_out,
+)
+
+
+def launch_kernel(
+    kernel, x, y, out=None, is_grad=False, dgrad=None, dx=None, dy=None
+):
+    n_elements = x.numel()
+    BLOCK_SIZE = 64
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+
+    if not is_grad:
+        if out is None:
+            out = torch.empty_like(x)
+        kernel[grid](x, y, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+        return out
+    kernel[grid](x, y, dgrad, dx, dy, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return dx, dy
+
+
+@pytest.mark.parametrize("size", [512, 1023, 1024])
+def test_silu_and_mul(size):
+    torch.manual_seed(0)
+    x = torch.randn(size, device="cpu", dtype=torch.float32)
+    y = torch.randn(size, device="cpu", dtype=torch.float32)
+
+    ref_out = torch.nn.functional.silu(x) * y
+
+    tri_out = launch_kernel(silu_and_mul_kernel, x, y)
+
+    torch.testing.assert_close(tri_out, ref_out, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("size", [512, 1023, 1024])
+def test_silu_and_mul_autograd(size):
+    torch.manual_seed(0)
+    x = torch.randn(
+        size, device="cpu", dtype=torch.float32, requires_grad=True
+    )
+    y = torch.randn(
+        size, device="cpu", dtype=torch.float32, requires_grad=True
+    )
+    dgrad = torch.randn(size, device="cpu", dtype=torch.float32)
+
+    ref_out = torch.nn.functional.silu(x) * y
+    tri_out = silu_and_mul(x, y)
+    torch.testing.assert_close(tri_out, ref_out, rtol=1e-4, atol=1e-4)
+
+    ref_out.backward(dgrad)
+    ref_dx, ref_dy = x.grad.clone(), y.grad.clone()
+
+    x.grad, y.grad = None, None
+    tri_out.backward(dgrad)
+    tri_dx, tri_dy = x.grad, y.grad
+
+    torch.testing.assert_close(tri_dx, ref_dx, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(tri_dy, ref_dy, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("size", [512, 1023, 1024])
+def test_silu_and_mul_out(size):
+    torch.manual_seed(0)
+    x = torch.randn(size, device="cpu", dtype=torch.float32)
+    y = torch.randn(size, device="cpu", dtype=torch.float32)
+    out = torch.empty_like(x)
+    ref_out = torch.nn.functional.silu(x) * y
+    silu_and_mul_out(x, y, out)
+
+    torch.testing.assert_close(out, ref_out, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("size", [512, 1023, 1024])
+@pytest.mark.parametrize("approximate", ["none", "tanh"])
+def test_gelu_and_mul(size, approximate):
+    torch.manual_seed(0)
+    x = torch.randn(size, device="cpu", dtype=torch.float32)
+    y = torch.randn(size, device="cpu", dtype=torch.float32)
+
+    ref_out = torch.nn.functional.gelu(x, approximate=approximate) * y
+
+    if approximate == "none":
+        tri_out = launch_kernel(gelu_none_and_mul_kernel, x, y)
+    else:
+        tri_out = launch_kernel(gelu_tanh_and_mul_kernel, x, y)
+
+    torch.testing.assert_close(tri_out, ref_out, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("size", [512, 1023, 1024])
+@pytest.mark.parametrize("approximate", ["none", "tanh"])
+def test_gelu_and_mul_autograd(size, approximate):
+    torch.manual_seed(0)
+    x = torch.randn(
+        size, device="cpu", dtype=torch.float32, requires_grad=True
+    )
+    y = torch.randn(
+        size, device="cpu", dtype=torch.float32, requires_grad=True
+    )
+    dgrad = torch.randn(size, device="cpu", dtype=torch.float32)
+
+    ref_out = torch.nn.functional.gelu(x, approximate=approximate) * y
+    tri_out = gelu_and_mul(x, y, approximate=approximate)
+    torch.testing.assert_close(tri_out, ref_out, rtol=1e-4, atol=1e-4)
+
+    ref_out.backward(dgrad)
+    ref_dx, ref_dy = x.grad.clone(), y.grad.clone()
+
+    x.grad, y.grad = None, None
+    tri_out.backward(dgrad)
+    tri_dx, tri_dy = x.grad, y.grad
+
+    torch.testing.assert_close(tri_dx, ref_dx, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(tri_dy, ref_dy, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("size", [512, 1023, 1024])
+def test_silu_grad_coverage(size):
+    torch.manual_seed(0)
+    x = torch.randn(size, device="cpu", dtype=torch.float32)
+    y = torch.randn(size, device="cpu", dtype=torch.float32)
+    dgrad = torch.randn(size, device="cpu", dtype=torch.float32)
+
+    dx = torch.empty_like(x)
+    dy = torch.empty_like(y)
+
+    launch_kernel(
+        silu_and_mul_grad_kernel,
+        x,
+        y,
+        is_grad=True,
+        dgrad=dgrad,
+        dx=dx,
+        dy=dy,
+    )
+
+
+@pytest.mark.parametrize("size", [512, 1023, 1024])
+@pytest.mark.parametrize("approximate", ["none", "tanh"])
+def test_gelu_grad_coverage(size, approximate):
+    torch.manual_seed(0)
+    x = torch.randn(size, device="cpu", dtype=torch.float32)
+    y = torch.randn(size, device="cpu", dtype=torch.float32)
+    dgrad = torch.randn(size, device="cpu", dtype=torch.float32)
+
+    dx = torch.empty_like(x)
+    dy = torch.empty_like(y)
+
+    kernel = (
+        gelu_none_and_mul_grad_kernel
+        if approximate == "none"
+        else gelu_tanh_and_mul_grad_kernel
+    )
+
+    launch_kernel(kernel, x, y, is_grad=True, dgrad=dgrad, dx=dx, dy=dy)


### PR DESCRIPTION
## Summary

Resolve #5 

This PR migrates and validates the FlagGems fused activation-gate operators (`silu_and_mul` and `gelu_and_mul`) in `python/examples/flaggems/`, with a pytest suite covering forward execution, autograd, and gradient kernel
coverage across multiple tensor sizes.

---

## Changes

### New files

| File                                         | Description                                               |
| -------------------------------------------- | --------------------------------------------------------- |
| `python/examples/flaggems/__init__.py`       | Package marker for pytest relative imports                |
| `python/examples/flaggems/silu_and_mul.py`   | Migrated SiLU-gate fused kernel + autograd                |
| `python/examples/flaggems/gelu_and_mul.py`   | Migrated GeLU-gate fused kernels (none & tanh) + autograd |
| `python/examples/flaggems/test_fused_ops.py` | pytest suite, 30 test cases                               |

---

## Test Results

**Environment:**

```log
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /home/maoxiao/WorkSpace/triton-riscv/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/maoxiao/WorkSpace/triton-riscv
configfile: pyproject.toml
plugins: xdist-3.8.0
collecting ... collected 30 items

9 failed, 21 passed in 3.33s
```

### Passed (21/30)

All `silu_and_mul` tests pass across all sizes (512, 1023, 1024):

All `gelu_and_mul[tanh]` tests pass across all sizes:

### Failed (9/30)

All failures are exclusively in `gelu_and_mul[approximate="none"]` variants
(forward, autograd, and grad coverage), across all three sizes.

---

## Root Cause Analysis

### Error Log

All 9 failures share an identical error at the MLIR lowering stage:

```log
python/examples/flaggems/test_fused_ops.py::test_gelu_and_mul[none-512] /tmp/tmpmj8m9jmh/ll.mlir:415:12: error: Dialect `math' not found for custom op 'math.erf'
    %317 = math.erf %316 : f32 loc(#loc22)
           ^
/tmp/tmpmj8m9jmh/ll.mlir:415:12: note: Registered dialects: acc, arm_neon, arm_sme, arm_sve, builtin, dlti, func, gpu, llvm, nvvm, omp, rocdl, spirv, vcix ; for more info on dialect registration see https://mlir.llvm.org/getting_started/Faq/#registered-loaded-dependent-whats-up-with-dialects-management
FAILED
```

The compilation then fails with:

```log
E           subprocess.CalledProcessError: Command '['/home/maoxiao/WorkSpace/buddy-mlir/llvm/build/bin/mlir-translate', '/tmp/tmpmj8m9jmh/ll.mlir', '--mlir-to-llvmir', '-o', '/tmp/tmpmj8m9jmh/ll.ir']' returned non-zero exit status 1.
```

### Analysis

`gelu_and_mul[approximate="none"]` uses `tl.erf`, which Triton lowers to `math.erf` in MLIR. The `mlir-translate` binary built
from `buddy-mlir/llvm/build/bin/` was compiled without the `math` dialect linked or registered. Since `math` does not
appear in the registered dialect list, `mlir-translate` cannot convert `math.erf` to an LLVM intrinsic and exits with a non-zero status.

It is a backend dialect gap in the triton-riscv / buddy-mlir build. The `gelu_and_mul[approximate="tanh"]` variant passes because its tanh approximation is computed entirely with `tl.exp` (there is no `tl.tanh` exposed), which lowers through standard arithmetic ops without requiring the `math` dialect.