### PR TITLE
Add Codex operator workflow validation

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -1,0 +1,66 @@
+# Codex Task Generation Flow
+
+This directory contains the simple task generation flow used by the
+Triton-RISCV operator workflow.
+
+## Purpose
+
+The generator turns an operator name and a small amount of context into a Codex
+task description file. The generated task tells Codex what to inspect, what it
+may modify, how to run validation, and how to record success or failure.
+
+## Generate a Task
+
+Run from the repository root:
+
+```sh
+python codex/generate_operator_task.py <operator>
+```
+
+Example:
+
+```sh
+python codex/generate_operator_task.py silu \
+  --semantics "SiLU computes x / (1 + exp(-x))." \
+  --pytorch-reference "torch.nn.functional.silu(x)" \
+  --triton-reference "python/examples/flaggems/silu.py" \
+  --inputs "x: input tensor" \
+  --outputs "output tensor with the same shape as x" \
+  --shapes "512, 1023, 1024" \
+  --dtypes "torch.float32, torch.float16, torch.float64" \
+  --implementation-file "python/examples/flaggems/silu.py" \
+  --test-file "python/examples/flaggems/test_silu.py" \
+  --test-command "python -m pytest -q python/examples/flaggems/test_silu.py -s"
+```
+
+By default, the generated file is written to:
+
+```text
+tasks/operators/<operator>.md
+```
+
+Use `--force` to overwrite an existing generated task.
+
+## Use the Generated Task
+
+1. Give the generated task file to Codex as the operator context.
+2. Ask Codex to inspect the listed implementation and test files.
+3. Ask Codex to implement, complete, or validate the operator step by step.
+4. Run the listed test command in a Triton-RISCV environment.
+5. Append the result to `experiment-results/operator-validation.md`.
+6. If a failure is found, update `docs/codex-operator-workflow.md` with the
+   missing diagnostic rule.
+
+## Current Validation Targets
+
+The first validation cycle used:
+
+- `silu`: passing elementwise activation validation.
+- `gelu`: mixed result; exact/erf-related paths expose a lowering issue.
+- `erf`: standalone failure-isolation case for `tl.math.erf` lowering.
+- `sigmoid_and_mul`: generated fused operator implementation that passed
+  forward and backward validation.
+- `relu_and_mul`: second generated fused operator implementation that passed
+  forward and backward validation.
+
+The baseline environment test used `vec_add`.

--- a/codex/generate_operator_task.py
+++ b/codex/generate_operator_task.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Generate a Codex operator task file from the shared template."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_PATH = REPO_ROOT / "codex" / "templates" / "operator-task.md"
+TASK_DIR = REPO_ROOT / "tasks" / "operators"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Triton-RISCV Codex operator task description."
+    )
+    parser.add_argument("operator", help="Operator name, for example silu or erf.")
+    parser.add_argument(
+        "--semantics",
+        default="Describe the operator semantics before asking Codex to edit code.",
+        help="Short operator semantics description.",
+    )
+    parser.add_argument(
+        "--pytorch-reference",
+        default=None,
+        help="PyTorch reference expression, for example torch.erf(x).",
+    )
+    parser.add_argument(
+        "--triton-reference",
+        default=None,
+        help="Existing Triton or FlagGems implementation path.",
+    )
+    parser.add_argument(
+        "--inputs",
+        default="input tensors required by the operator",
+        help="Input contract text.",
+    )
+    parser.add_argument(
+        "--outputs",
+        default="output tensor matching the operator semantics",
+        help="Output contract text.",
+    )
+    parser.add_argument(
+        "--shapes",
+        default="start with small one-dimensional shapes such as 512, 1023, and 1024",
+        help="Shape coverage text.",
+    )
+    parser.add_argument(
+        "--dtypes",
+        default="start with torch.float32, then extend if supported",
+        help="Dtype coverage text.",
+    )
+    parser.add_argument(
+        "--implementation-file",
+        default=None,
+        help="Implementation file Codex may inspect or modify.",
+    )
+    parser.add_argument(
+        "--test-file",
+        default=None,
+        help="Pytest file Codex may inspect or modify.",
+    )
+    parser.add_argument(
+        "--test-command",
+        default=None,
+        help="Command used to validate the operator.",
+    )
+    parser.add_argument(
+        "--additional-files",
+        default="no additional files",
+        help="Additional files Codex should inspect.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output task file. Defaults to tasks/operators/<operator>.md.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing task file.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    operator = args.operator
+    implementation_file = (
+        args.implementation_file
+        or f"python/examples/flaggems/{operator}.py"
+    )
+    test_file = args.test_file or f"python/examples/flaggems/test_{operator}.py"
+    pytorch_reference = args.pytorch_reference or f"torch.<reference_for_{operator}>"
+    triton_reference = args.triton_reference or implementation_file
+    test_command = (
+        args.test_command
+        or f"python -m pytest -q {test_file} -s"
+    )
+    output_path = Path(args.output) if args.output else TASK_DIR / f"{operator}.md"
+    if not output_path.is_absolute():
+        output_path = REPO_ROOT / output_path
+
+    if output_path.exists() and not args.force:
+        raise SystemExit(
+            f"{output_path} already exists; pass --force to overwrite it."
+        )
+
+    template = TEMPLATE_PATH.read_text(encoding="utf-8")
+    replacements = {
+        "{{OPERATOR_NAME}}": operator,
+        "{{OPERATOR_SEMANTICS}}": args.semantics,
+        "{{PYTORCH_REFERENCE}}": pytorch_reference,
+        "{{TRITON_REFERENCE}}": triton_reference,
+        "{{INPUTS}}": args.inputs,
+        "{{OUTPUTS}}": args.outputs,
+        "{{SHAPES}}": args.shapes,
+        "{{DTYPES}}": args.dtypes,
+        "{{ADDITIONAL_FILES_TO_INSPECT}}": args.additional_files,
+        "{{IMPLEMENTATION_FILE}}": implementation_file,
+        "{{TEST_FILE}}": test_file,
+        "{{TEST_COMMAND}}": test_command,
+    }
+
+    content = template
+    for placeholder, value in replacements.items():
+        content = content.replace(placeholder, value)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+    print(f"generated {output_path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/templates/operator-task.md
+++ b/codex/templates/operator-task.md
@@ -1,0 +1,150 @@
+# Operator Task: {{OPERATOR_NAME}}
+
+## Objective
+
+Implement or complete the Triton-RISCV operator `{{OPERATOR_NAME}}` using the
+workflow in `docs/codex-operator-workflow.md`.
+
+## Operator Semantics
+
+{{OPERATOR_SEMANTICS}}
+
+## Reference Implementation
+
+- PyTorch reference:
+  - `{{PYTORCH_REFERENCE}}`
+- Existing Triton or FlagGems reference:
+  - `{{TRITON_REFERENCE}}`
+
+## Input and Output Contract
+
+- Inputs:
+  - `{{INPUTS}}`
+- Outputs:
+  - `{{OUTPUTS}}`
+- Shapes:
+  - `{{SHAPES}}`
+- Dtypes:
+  - `{{DTYPES}}`
+
+## Files to Inspect
+
+Codex should inspect these files before editing code:
+
+- `README.md`
+- `docs/05-Operator Migration.md`
+- `python/examples/`
+- `python/examples/flaggems/`
+- `{{ADDITIONAL_FILES_TO_INSPECT}}`
+
+## Files to Modify
+
+Codex may modify or add only the files needed for this operator:
+
+- `{{IMPLEMENTATION_FILE}}`
+- `{{TEST_FILE}}`
+
+If other files appear necessary, explain why before modifying them.
+
+## Triton-RISCV Constraints
+
+Avoid unsupported or risky features unless the existing repository already uses
+them successfully for a similar operator.
+
+- Avoid autotuning in the initial implementation.
+- Prefer simple block-based elementwise kernels for first validation.
+- Compare against existing examples before introducing new Triton patterns.
+- Keep pointer arithmetic, masking, and dtype conversions explicit.
+
+## Environment Prerequisite Check
+
+Before running build or test commands, check that:
+
+- `../triton` exists, or `TRITON_DIR` points to a valid Triton checkout
+- `../buddy-mlir` exists, or `BUDDY_DIR` points to a valid Buddy MLIR checkout
+- `.venv` or the configured Python environment is available
+- `pytest` is available in the active environment
+- `scripts/triton-riscv-env.sh` can be sourced without path errors
+- the host architecture is supported by the selected build path
+
+If any item is missing, do not mark the operator as failed. Record an
+environment setup failure in the validation log.
+
+## Implementation Steps
+
+1. Read the reference implementation and existing nearby examples.
+2. Run the environment prerequisite check.
+3. Write or complete the Triton kernel.
+4. Add a Python wrapper if needed.
+5. Add or update pytest coverage.
+6. Compare results against the PyTorch reference implementation.
+7. Run the requested test command.
+8. Record the result in the validation log.
+
+## Failure Triage Steps
+
+If the test fails, classify the failure before modifying code:
+
+1. Environment failure: missing Triton checkout, Buddy checkout, Python
+   environment, pytest, or unsupported host architecture.
+2. Import failure: Python cannot import the implementation or test module.
+3. Triton compilation failure: JIT starts, but compilation fails before runtime.
+4. MLIR lowering or translation failure: generated MLIR cannot be translated to
+   LLVM IR.
+5. Runtime failure: compiled code launches but crashes or returns invalid data.
+6. Correctness failure: execution completes, but output differs from the PyTorch
+   reference.
+
+For MLIR lowering or translation failures, search the log for unsupported
+dialect operations. If the log contains `linalg.generic` or `Dialect linalg not
+found`, record the failure as a compiler/lowering coverage issue unless there is
+clear evidence that the operator implementation generated invalid semantics.
+
+Do not modify compiler internals or unrelated operator code as part of this task
+unless the task explicitly asks for a compiler fix.
+
+## Build and Test Commands
+
+Set up the environment:
+
+```sh
+source scripts/triton-riscv-env.sh
+```
+
+Run the relevant test:
+
+```sh
+{{TEST_COMMAND}}
+```
+
+If the implementation requires a rebuild, run:
+
+```sh
+scripts/rebuild-triton-riscv.sh
+```
+
+## Success Criteria
+
+- The operator implementation matches the stated semantics.
+- The test compares against a PyTorch reference implementation.
+- The relevant pytest command passes.
+- Any unsupported cases are documented.
+
+## Validation Attempts
+
+Append a new attempt entry after each validation run. Do not replace older
+attempts.
+
+### Attempt 1: TODO
+
+- Operator:
+- Task file:
+- Implementation files:
+- Test command:
+- Failure stage:
+- Compilation result:
+- Test result:
+- Failure log:
+- Residual IR or dialect issue:
+- Likely failure reason:
+- Workflow improvement:

--- a/docs/codex-operator-workflow.md
+++ b/docs/codex-operator-workflow.md
@@ -1,0 +1,203 @@
+# Codex Operator Workflow for Triton-RISCV
+
+This document defines a reusable workflow for guiding Codex to generate,
+complete, compile, and test Triton operators for Triton-RISCV.
+
+## Goal
+
+The goal is not only to implement one operator. The goal is to create a
+repeatable process that gives Codex enough context to work on Triton-RISCV
+operators, then evaluate whether Codex follows the process successfully.
+
+## Workflow Loop
+
+1. Select an operator.
+2. Collect operator context.
+3. Generate a Codex task description.
+4. Ask Codex to implement or complete the operator.
+5. Build and test the result.
+6. Record success, failure logs, and likely failure reasons.
+7. Update this workflow based on what Codex missed.
+
+The loop should be treated as an experiment cycle. A failed operator test does
+not always mean the operator implementation is wrong. Codex must first identify
+whether the failure is caused by environment setup, Python import, Triton
+compilation, MLIR lowering, runtime execution, or numerical correctness.
+
+## Operator Context
+
+For each operator, collect the following information before asking Codex to
+write code:
+
+- Operator name
+- Operator semantics
+- PyTorch reference implementation
+- Existing Triton or FlagGems reference implementation
+- Expected input and output shapes
+- Expected dtypes
+- Files that Codex should inspect
+- Files that Codex may modify
+- Triton-RISCV limitations to avoid
+
+## Task Generation Flow
+
+Use the task generator to create an operator-specific Codex task file:
+
+```sh
+python codex/generate_operator_task.py <operator>
+```
+
+The generator reads `codex/templates/operator-task.md` and writes:
+
+```text
+tasks/operators/<operator>.md
+```
+
+Pass operator-specific context such as semantics, PyTorch reference,
+implementation file, test file, and validation command through generator
+arguments. See `codex/README.md` for an example.
+
+After generation, Codex should complete the task file with the actual validation
+attempts and any workflow feedback discovered during testing.
+
+## Environment Prerequisite Check
+
+Before building or testing an operator, Codex should check that the local
+Triton-RISCV environment is available. If the environment is missing, record the
+missing prerequisite instead of treating it as an operator failure.
+
+Check the following items:
+
+- `../triton` exists, or `TRITON_DIR` points to a valid Triton checkout
+- `../buddy-mlir` exists, or `BUDDY_DIR` points to a valid Buddy MLIR checkout
+- the Python environment exists, usually `.venv`
+- `pytest` is available in the active environment
+- `scripts/triton-riscv-env.sh` can be sourced without path errors
+- the host architecture is supported by the chosen setup path; for example,
+  `scripts/build.sh` currently supports `x86_64`/`amd64` and `riscv64`
+
+If any prerequisite is missing, stop before running operator tests and record an
+environment setup failure in the validation log.
+
+## Suggested Files
+
+Codex should usually inspect:
+
+- `python/examples/`
+- `python/examples/flaggems/`
+- `docs/05-Operator Migration.md`
+- `README.md`
+
+Codex should usually modify or add:
+
+- a Python example or operator implementation under `python/examples/`
+- a pytest test case under `python/examples/`
+- a task description under `tasks/operators/`
+
+## Compilation and Test Commands
+
+Use the repository environment helper before running build or test commands:
+
+```sh
+source scripts/triton-riscv-env.sh
+```
+
+Build or rebuild Triton-RISCV:
+
+```sh
+scripts/rebuild-triton-riscv.sh
+```
+
+Run the relevant operator test:
+
+```sh
+python -m pytest -q python/examples/flaggems/test_<operator>.py -s
+```
+
+Save each validation run to a timestamped log:
+
+```sh
+mkdir -p test-logs
+log="test-logs/<operator>-$(date +%Y%m%d-%H%M%S).log"
+python -m pytest -q python/examples/flaggems/test_<operator>.py -s 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+echo "exit=$status" | tee -a "$log"
+```
+
+Use the saved log path in the validation record.
+
+## Compilation Failure Triage
+
+When a pytest case fails during compilation, Codex should classify the failure
+before changing any implementation file.
+
+Use this order:
+
+1. Check whether the environment was loaded correctly.
+2. Check whether the Python test imports the intended operator.
+3. Check whether Triton JIT compilation started.
+4. Check whether the failure happened in Triton-RISCV lowering or MLIR
+   translation.
+5. Check whether execution reached the PyTorch reference comparison.
+
+If the log contains an error like:
+
+```text
+Dialect linalg not found for custom op linalg.generic
+```
+
+then record the failure as an MLIR lowering or translation failure. Do not treat
+it as a numerical correctness failure. Codex should inspect the lowering
+pipeline and whether `linalg.generic` remains before `mlir-translate
+--mlir-to-llvmir`. In this case, the workflow improvement should be to add a
+pre-translation IR check or to document the unsupported math/linalg lowering
+path.
+
+## Success Criteria
+
+An operator attempt is successful when:
+
+- the implementation follows the selected operator semantics
+- the code compiles through the Triton-RISCV flow
+- the pytest reference comparison passes
+- the result is compared against a PyTorch reference implementation
+- any limitations or unsupported cases are documented
+
+A validation attempt can still be useful when it fails, as long as the workflow
+records the exact failing stage, log file, and likely reason. In that case, the
+workflow update is the deliverable, not an unproven code change.
+
+## Failure Record
+
+For each validation run, append a new attempt entry instead of replacing older
+results. This keeps the workflow evolution visible across repeated tests.
+
+For each failed attempt, record:
+
+- operator name
+- task file used
+- command that failed
+- short error log
+- failure stage: generation, import, compilation, runtime, or correctness
+- likely failure reason
+- possible workflow improvement
+
+For compilation failures, also record:
+
+- whether the failing command was `triton-shared-opt`, `buddy-opt`,
+  `mlir-translate`, `llc`, or pytest itself
+- whether the generated MLIR still contains unsupported dialect operations such
+  as `linalg.generic`
+- whether the failure is shared by related operators, for example `gelu`
+  failing together with standalone `erf`
+
+## Initial Validation Operators
+
+Start with simple operators before trying larger kernels:
+
+- baseline: `vec_add`
+- passing operator: `silu`
+- mixed-result operator: `gelu`
+- related failure-isolation operator: `erf`
+- generated fused operator: `sigmoid_and_mul`
+- generated fused operator: `relu_and_mul`

--- a/experiment-results/operator-validation.md
+++ b/experiment-results/operator-validation.md
@@ -1,0 +1,304 @@
+# Operator Validation Results
+
+## Environment Check
+
+- Machine: sg2044
+- Architecture: riscv64
+- Python: 3.11.6
+- Triton: 3.4.0
+- LLVM/Buddy: 22.0.0git
+- Triton-RISCV backend: triton_shared
+
+The environment can load Triton, locate triton-shared-opt, and locate buddy-opt.
+
+## Task Generation Flow Check
+
+### Purpose
+
+This check verifies that the workflow includes a repeatable way to generate a
+Codex task description for a selected operator.
+
+### Command
+
+```bash
+python3 codex/generate_operator_task.py silu \
+  --semantics "SiLU computes x / (1 + exp(-x)). This validation task uses the existing forward operator and pytest reference comparison." \
+  --pytorch-reference "torch.nn.functional.silu(x)" \
+  --triton-reference "python/examples/flaggems/silu.py" \
+  --inputs "x: input tensor" \
+  --outputs "output tensor with the same shape as x" \
+  --shapes "512, 1023, 1024" \
+  --dtypes "torch.float32, torch.float16, torch.float64" \
+  --implementation-file "python/examples/flaggems/silu.py" \
+  --test-file "python/examples/flaggems/test_silu.py" \
+  --test-command "python -m pytest -q python/examples/flaggems/test_silu.py -s"
+```
+
+### Result
+
+- Status: passed
+- Generated task file: `tasks/operators/silu.md`
+- The generated task was completed with the real validation result from the
+  server run.
+
+## Baseline Test: vec_add
+
+### Purpose
+
+This baseline test verifies that the Triton-RISCV environment, compilation flow, backend registration, and basic CPU execution path are working before validating new operators.
+
+### Command
+
+```bash
+python -m pytest -q python/examples/test_vec_add.py -s
+```
+
+### Result
+
+- Status: passed
+- Pytest result: 1 passed
+- Exit code: 0
+- Log file: test-logs/vec_add-20260602-232423.log
+- Numerical result: maximum difference between torch and triton was 0.0
+
+### Notes
+
+The log printed `Error in cpuinfo: processor architecture is not supported in cpuinfo`, but the test still passed. This warning does not block the current validation.
+
+## Operator Validation 1: silu
+
+### Purpose
+
+This validation checks a simple elementwise activation operator after the baseline environment test.
+
+### Files Inspected
+
+- python/examples/flaggems/silu.py
+- python/examples/flaggems/test_silu.py
+
+### Command
+
+```bash
+python -m pytest -q python/examples/flaggems/test_silu.py -s
+```
+
+### Result
+
+- Status: passed
+- Pytest result: 10 passed
+- Exit code: 0
+- Log file: test-logs/silu-20260602-234455.log
+
+### Workflow Feedback
+
+The workflow is effective for an existing elementwise operator: it identifies the implementation and test files, runs the Triton-RISCV compilation/execution flow, and records a clean pass result.
+
+## Operator Validation 2: gelu
+
+### Purpose
+
+This validation checks whether the workflow can handle a more complex elementwise operator with multiple code paths. GELU includes exact erf, tanh approximation, in-place execution, backward computation, and dtype coverage.
+
+### Files Inspected
+
+- python/examples/flaggems/gelu.py
+- python/examples/flaggems/test_gelu.py
+
+### Command
+
+```bash
+python -m pytest -q python/examples/flaggems/test_gelu.py -s
+```
+
+### Result
+
+- Status: failed
+- Pytest result: 9 failed, 5 passed
+- Exit code: 1
+- Log file: test-logs/gelu-20260602-235012.log
+
+### Failure Summary
+
+The failing GELU cases stopped during the Triton-RISCV compilation flow.
+
+Main error:
+
+```text
+error: Dialect linalg not found for custom op linalg.generic
+```
+
+Failed cases:
+
+- test_gelu_none
+- test_gelu_inplace
+- test_gelu_backward with approximate none
+- test_gelu_dtype
+
+### Possible Reason
+
+Some GELU paths produce or keep `linalg.generic` in the generated MLIR. The following translation step does not handle the linalg dialect, so compilation fails before numerical comparison.
+
+### Workflow Feedback
+
+The workflow is useful here because it captures an operator-specific compiler failure and records the exact log and likely failure reason.
+
+## Operator Validation 3: erf
+
+### Purpose
+
+This validation checks the standalone error function operator. It was selected after GELU failed because the exact GELU path depends on erf-like math lowering, so this test helps isolate whether the failure is related to erf itself.
+
+### Files Inspected
+
+- python/examples/flaggems/erf.py
+- python/examples/flaggems/test_erf.py
+
+### Command
+
+```bash
+python -m pytest -q python/examples/flaggems/test_erf.py -s
+```
+
+### Result
+
+- Status: failed
+- Pytest result: 18 failed
+- Exit code: 1
+- Log file: test-logs/erf-20260603-010841.log
+
+### Failure Summary
+
+All tested erf cases failed during compilation before numerical comparison.
+
+Main error:
+
+```text
+error: Dialect linalg not found for custom op linalg.generic
+```
+
+Failed cases:
+
+- test_erf for float32, float16, and float64
+- test_erf_inplace for float32, float16, and float64
+- shapes 512, 1023, and 1024
+
+### Possible Reason
+
+The standalone erf operator uses `tl.math.erf`, and that lowering produces or retains `linalg.generic` in the generated MLIR. Since the following translation stage does not handle the linalg dialect, compilation fails before the reference comparison can run.
+
+### Workflow Feedback
+
+This result strengthens the GELU diagnosis. The workflow can now report that GELU's exact path failure is likely connected to erf/math lowering rather than only GELU wrapper logic.
+
+## Generated Operator Validation: sigmoid_and_mul
+
+## Generated Operator Result Summary
+
+| Operator | Compilation Result | Test Result | Log File | Failure Log | Possible Failure Reason |
+| --- | --- | --- | --- | --- | --- |
+| `sigmoid_and_mul` | passed through Triton-RISCV JIT compilation and execution | 9 passed, exit 0 | `test-logs/sigmoid_and_mul-20260603-023700.log` | none | not applicable |
+| `relu_and_mul` | passed through Triton-RISCV JIT compilation and execution | 9 passed, exit 0 | `test-logs/relu_and_mul-20260603-034746.log` | none | not applicable |
+
+### Purpose
+
+This validation checks the full workflow on a generated fused operator. Unlike
+the previous existing-operator checks, this attempt added a new operator
+implementation and a new pytest file, then ran the Triton-RISCV validation flow.
+
+### Operator Semantics
+
+`sigmoid_and_mul` computes:
+
+```text
+output = sigmoid(x) * y
+```
+
+The backward helper computes:
+
+```text
+dx = grad_output * y * sigmoid(x) * (1 - sigmoid(x))
+dy = grad_output * sigmoid(x)
+```
+
+### Files Added
+
+- `python/examples/flaggems/sigmoid_and_mul.py`
+- `python/examples/flaggems/test_sigmoid_and_mul.py`
+- `tasks/operators/sigmoid_and_mul.md`
+
+### Command
+
+```bash
+python -m pytest -q python/examples/flaggems/test_sigmoid_and_mul.py -s
+```
+
+### Result
+
+- Status: passed
+- Compilation result: passed through Triton-RISCV JIT compilation and execution
+- Pytest result: 9 passed
+- Exit code: 0
+- Log file: `test-logs/sigmoid_and_mul-20260603-023700.log`
+- Failure log: none
+- Possible failure reason: not applicable
+
+### Workflow Feedback
+
+This validation shows that the generated task flow can guide a small fused
+elementwise operator from task description to implementation, pytest coverage,
+Triton-RISCV compilation, execution, and numerical reference comparison.
+
+The passing result also supports the earlier diagnosis: exp-based elementwise
+math can compile successfully, while the GELU/ERF failures are more likely tied
+to erf/math lowering that leaves `linalg.generic`.
+
+## Generated Operator Validation: relu_and_mul
+
+### Purpose
+
+This validation checks a second generated fused operator using the same task
+generation workflow. The operator was selected as a simple supported elementwise
+fusion to confirm that the workflow is reusable beyond one generated example.
+
+### Operator Semantics
+
+`relu_and_mul` computes:
+
+```text
+output = relu(x) * y
+```
+
+The backward helper computes:
+
+```text
+dx = grad_output * y * (x > 0)
+dy = grad_output * relu(x)
+```
+
+### Files Added
+
+- `python/examples/flaggems/relu_and_mul.py`
+- `python/examples/flaggems/test_relu_and_mul.py`
+- `tasks/operators/relu_and_mul.md`
+
+### Command
+
+```bash
+python -m pytest -q python/examples/flaggems/test_relu_and_mul.py -s
+```
+
+### Result
+
+- Status: passed
+- Compilation result: passed through Triton-RISCV JIT compilation and execution
+- Pytest result: 9 passed
+- Exit code: 0
+- Log file: `test-logs/relu_and_mul-20260603-034746.log`
+- Failure log: none
+- Possible failure reason: not applicable
+
+### Workflow Feedback
+
+This validation shows that the generated task flow can be reused for a second
+new fused operator. The implementation, pytest coverage, Triton-RISCV
+compilation, execution, and PyTorch reference comparison all passed.

--- a/experiment-results/summary.md
+++ b/experiment-results/summary.md
@@ -1,0 +1,200 @@
+# Triton-RISCV Codex Operator Workflow Summary
+
+## Objective
+
+This work builds a Codex-compatible operator generation and compilation workflow
+for Triton-RISCV. The workflow is intended to help Codex understand an operator
+task, collect the right context, generate or complete an operator task
+description, run the Triton-RISCV validation flow, and record success or failure
+with useful diagnostics.
+
+## Implemented Workflow Components
+
+- `docs/codex-operator-workflow.md`
+  - Reusable workflow for selecting an operator, collecting context, running
+    build/test commands, recording results, and updating the workflow.
+- `codex/templates/operator-task.md`
+  - Generic task template for Codex operator work.
+- `codex/generate_operator_task.py`
+  - Simple task generation script that creates `tasks/operators/<operator>.md`
+    from the template and operator context.
+- `codex/README.md`
+  - Instructions for using the task generation flow.
+- `tasks/operators/*.md`
+  - Concrete operator task descriptions used in the first validation cycle.
+- `experiment-results/operator-validation.md`
+  - Experiment record with environment checks, commands, results, logs, and
+    failure analysis.
+
+## Validation Environment
+
+- Machine: `sg2044`
+- Architecture: `riscv64`
+- Python: 3.11.6
+- Triton: 3.4.0
+- LLVM/Buddy: 22.0.0git
+- Backend: `triton_shared`
+
+The environment successfully loaded Triton, found `triton-shared-opt`, and found
+`buddy-opt`.
+
+## Validation Targets
+
+The first validation cycle used existing repository operators and tests to
+validate the workflow, then added two generated fused operators to exercise the
+implementation path.
+
+| Target | Role | Result | Log |
+| --- | --- | --- | --- |
+| `vec_add` | baseline environment and compilation-flow check | 1 passed | `test-logs/vec_add-20260602-232423.log` |
+| `silu` | passing elementwise operator validation | 10 passed | `test-logs/silu-20260602-234455.log` |
+| `gelu` | multi-path activation validation | 9 failed, 5 passed | `test-logs/gelu-20260602-235012.log` |
+| `erf` | standalone math-lowering isolation case | 18 failed | `test-logs/erf-20260603-010841.log` |
+| `sigmoid_and_mul` | generated fused operator implementation and validation | 9 passed | `test-logs/sigmoid_and_mul-20260603-023700.log` |
+| `relu_and_mul` | generated fused operator implementation and validation | 9 passed | `test-logs/relu_and_mul-20260603-034746.log` |
+
+## Key Findings
+
+The baseline `vec_add` and the `silu` operator passed, showing that the
+environment and a simple elementwise compilation path work.
+
+`gelu` partially failed during compilation. The failing cases were related to
+exact GELU, in-place GELU, backward exact GELU, and dtype coverage. The main
+error was:
+
+```text
+error: Dialect linalg not found for custom op linalg.generic
+```
+
+`erf` failed for all tested cases with the same `linalg.generic` issue. This
+supports the diagnosis that the GELU exact-mode failure is likely related to
+`tl.math.erf` or math lowering, rather than only GELU wrapper logic.
+
+`sigmoid_and_mul` was added as a generated fused operator after the workflow and
+task generator were created. Its forward and backward tests passed, showing that
+the workflow can guide a small supported operator from task generation to code,
+tests, compilation, execution, and reference comparison.
+
+`relu_and_mul` was added as a second generated fused operator. Its forward and
+backward tests also passed, showing that the workflow is reusable for more than
+one new operator.
+
+## Workflow Improvements After Validation
+
+The initial workflow was updated after the GELU and ERF failures.
+
+Added improvements:
+
+- Failure-stage triage:
+  - environment
+  - import
+  - Triton compilation
+  - MLIR lowering or translation
+  - runtime
+  - numerical correctness
+- Timestamped validation logs under `test-logs/`.
+- Explicit exit-code recording.
+- Special handling for `linalg.generic` and `Dialect linalg not found` errors.
+- Guidance that Codex should not modify operator code when the failure is a
+  compiler/lowering coverage issue.
+- Cross-operator diagnosis: use standalone math operators such as `erf` to
+  isolate failures seen in larger operators such as `gelu`.
+
+## Effectiveness
+
+### Operator Task Generation
+
+The workflow now includes a simple generation flow:
+
+```sh
+python codex/generate_operator_task.py <operator>
+```
+
+This was used to generate `tasks/operators/silu.md`, which was then completed
+with the real validation result. It was also used to generate
+`tasks/operators/sigmoid_and_mul.md` and `tasks/operators/relu_and_mul.md` for
+new fused operator implementations.
+
+### Compilation Validation
+
+The workflow successfully runs operator tests through the Triton-RISCV path and
+records whether the failure happens before or after runtime execution.
+
+The passing `silu` case shows that simple elementwise operators can be validated
+end to end.
+
+The passing `sigmoid_and_mul` case shows that the workflow can also support a
+small generated fused operator, including a new implementation file and a new
+pytest file.
+
+The passing `relu_and_mul` case confirms that the same process can be repeated
+for another generated fused operator.
+
+### Error Feedback
+
+The workflow identifies that `gelu` and `erf` fail before numerical comparison,
+during MLIR lowering or translation. This produces more useful feedback than a
+generic pytest failure, because it points future Codex runs toward compiler
+coverage or lowering-pipeline investigation.
+
+## Reusable Foundation
+
+The workflow can be reused for additional Triton operators because it separates
+the common process from operator-specific context.
+
+Reusable parts:
+
+- `docs/codex-operator-workflow.md` defines the shared loop for context
+  collection, task generation, implementation, compilation, testing, and
+  feedback.
+- `codex/templates/operator-task.md` defines the common task structure.
+- `codex/generate_operator_task.py` creates a new task file for a selected
+  operator.
+- `tasks/operators/<operator>.md` stores the operator-specific semantics,
+  reference implementation, files to inspect or modify, commands, and success
+  criteria.
+- `experiment-results/operator-validation.md` records each validation run in a
+  comparable format.
+
+This structure helps improve Triton-RISCV compiler coverage in two ways:
+
+- Passing generated operators such as `sigmoid_and_mul` and `relu_and_mul`
+  become examples for supported lowering patterns.
+- Failing operators such as `gelu` and `erf` become small compiler-coverage
+  reports with exact logs and likely failure stages.
+
+As more operators are added, the same workflow can classify them as supported,
+unsupported, or requiring compiler/lowering work.
+
+## Limitations
+
+This validation cycle did not modify compiler source files. It added two small
+operator implementations, `sigmoid_and_mul` and `relu_and_mul`, to validate the
+generation and completion path. GELU and ERF implementation files were not
+modified because their failures were classified as compiler/lowering coverage
+issues, not proven operator implementation mistakes.
+
+The current workflow can diagnose the `linalg.generic` failure, but it does not
+itself fix the compiler pipeline. A future compiler-fix task would be needed to
+make the failing GELU and ERF cases pass.
+
+## Future Work
+
+- Use the generator to create task descriptions for more operators.
+- Add a pre-translation IR check that detects unsupported dialect operations
+  before `mlir-translate --mlir-to-llvmir`.
+- Create a separate compiler-fix task for math/linalg lowering issues.
+- Extend validation from existing operators to missing or incomplete operators.
+- Add a small regression set that groups passing operators, expected failures,
+  and compiler-coverage gaps.
+
+## Deliverables
+
+- Workflow: `docs/codex-operator-workflow.md`
+- Task template: `codex/templates/operator-task.md`
+- Task generator: `codex/generate_operator_task.py`
+- Generator instructions: `codex/README.md`
+- Operator tasks: `tasks/operators/`
+- Experiment record: `experiment-results/operator-validation.md`
+- Final summary: `experiment-results/summary.md`
+- Server logs: `test-logs/*.log`

--- a/python/examples/flaggems/relu_and_mul.py
+++ b/python/examples/flaggems/relu_and_mul.py
@@ -1,0 +1,72 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def relu_and_mul_kernel(
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask).to(tl.float32)
+    relu = tl.maximum(x, 0.0)
+    tl.store(out_ptr + offsets, relu * y, mask=mask)
+
+
+@triton.jit
+def relu_and_mul_backward_kernel(
+    grad_ptr,
+    x_ptr,
+    y_ptr,
+    dx_ptr,
+    dy_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    grad = tl.load(grad_ptr + offsets, mask=mask).to(tl.float32)
+    x = tl.load(x_ptr + offsets, mask=mask).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask).to(tl.float32)
+    relu = tl.maximum(x, 0.0)
+    relu_grad = x > 0.0
+    tl.store(dx_ptr + offsets, grad * y * relu_grad, mask=mask)
+    tl.store(dy_ptr + offsets, grad * relu, mask=mask)
+
+
+def relu_and_mul(x, y):
+    x, y = torch.broadcast_tensors(x, y)
+    x_c = x.contiguous()
+    y_c = y.contiguous()
+    out = torch.empty_like(x_c)
+    n_elements = x_c.numel()
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+    relu_and_mul_kernel[grid](
+        x_c, y_c, out, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return out.view_as(x)
+
+
+def relu_and_mul_backward(grad_output, x, y):
+    x, y, grad_output = torch.broadcast_tensors(x, y, grad_output)
+    x_c = x.contiguous()
+    y_c = y.contiguous()
+    grad_c = grad_output.contiguous()
+    dx = torch.empty_like(x_c)
+    dy = torch.empty_like(y_c)
+    n_elements = x_c.numel()
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+    relu_and_mul_backward_kernel[grid](
+        grad_c, x_c, y_c, dx, dy, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return dx.view_as(x), dy.view_as(y)

--- a/python/examples/flaggems/sigmoid_and_mul.py
+++ b/python/examples/flaggems/sigmoid_and_mul.py
@@ -1,0 +1,75 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sigmoid_and_mul_kernel(
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    x_f32 = x.to(tl.float32)
+    y_f32 = y.to(tl.float32)
+    sigmoid = 1.0 / (1.0 + tl.exp(-x_f32))
+    tl.store(out_ptr + offsets, sigmoid * y_f32, mask=mask)
+
+
+@triton.jit
+def sigmoid_and_mul_backward_kernel(
+    grad_ptr,
+    x_ptr,
+    y_ptr,
+    dx_ptr,
+    dy_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    grad = tl.load(grad_ptr + offsets, mask=mask).to(tl.float32)
+    x = tl.load(x_ptr + offsets, mask=mask).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask).to(tl.float32)
+    sigmoid = 1.0 / (1.0 + tl.exp(-x))
+    dx = grad * y * sigmoid * (1.0 - sigmoid)
+    dy = grad * sigmoid
+    tl.store(dx_ptr + offsets, dx, mask=mask)
+    tl.store(dy_ptr + offsets, dy, mask=mask)
+
+
+def sigmoid_and_mul(x, y):
+    x, y = torch.broadcast_tensors(x, y)
+    x_c = x.contiguous()
+    y_c = y.contiguous()
+    out = torch.empty_like(x_c)
+    n_elements = x_c.numel()
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+    sigmoid_and_mul_kernel[grid](
+        x_c, y_c, out, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return out.view_as(x)
+
+
+def sigmoid_and_mul_backward(grad_output, x, y):
+    x, y, grad_output = torch.broadcast_tensors(x, y, grad_output)
+    x_c = x.contiguous()
+    y_c = y.contiguous()
+    grad_c = grad_output.contiguous()
+    dx = torch.empty_like(x_c)
+    dy = torch.empty_like(y_c)
+    n_elements = x_c.numel()
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+    sigmoid_and_mul_backward_kernel[grid](
+        grad_c, x_c, y_c, dx, dy, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return dx.view_as(x), dy.view_as(y)

--- a/python/examples/flaggems/test_relu_and_mul.py
+++ b/python/examples/flaggems/test_relu_and_mul.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from .relu_and_mul import relu_and_mul, relu_and_mul_backward
+
+
+@pytest.mark.parametrize("shape", [(512,), (1023,), (1024,)])
+@pytest.mark.parametrize(
+    "dtype,rtol,atol",
+    [
+        (torch.float32, 1e-4, 1e-4),
+        (torch.float16, 1e-2, 1e-2),
+    ],
+)
+def test_relu_and_mul_forward(shape, dtype, rtol, atol):
+    torch.manual_seed(0)
+    x = torch.randn(shape, dtype=dtype, device="cpu")
+    y = torch.randn(shape, dtype=dtype, device="cpu")
+
+    ref = torch.relu(x) * y
+    tri = relu_and_mul(x, y)
+
+    torch.testing.assert_close(tri, ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("shape", [(512,), (1023,), (1024,)])
+def test_relu_and_mul_backward(shape):
+    torch.manual_seed(0)
+    x = torch.randn(shape, dtype=torch.float32, device="cpu", requires_grad=True)
+    y = torch.randn(shape, dtype=torch.float32, device="cpu", requires_grad=True)
+
+    ref = torch.relu(x) * y
+    grad_output = torch.randn_like(ref)
+    ref.backward(grad_output)
+    ref_dx = x.grad.clone()
+    ref_dy = y.grad.clone()
+
+    tri_dx, tri_dy = relu_and_mul_backward(grad_output, x.detach(), y.detach())
+
+    torch.testing.assert_close(tri_dx, ref_dx, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(tri_dy, ref_dy, rtol=1e-4, atol=1e-4)

--- a/python/examples/flaggems/test_sigmoid_and_mul.py
+++ b/python/examples/flaggems/test_sigmoid_and_mul.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from .sigmoid_and_mul import sigmoid_and_mul, sigmoid_and_mul_backward
+
+
+@pytest.mark.parametrize("shape", [(512,), (1023,), (1024,)])
+@pytest.mark.parametrize(
+    "dtype,rtol,atol",
+    [
+        (torch.float32, 1e-4, 1e-4),
+        (torch.float16, 1e-2, 1e-2),
+    ],
+)
+def test_sigmoid_and_mul_forward(shape, dtype, rtol, atol):
+    torch.manual_seed(0)
+    x = torch.randn(shape, dtype=dtype, device="cpu")
+    y = torch.randn(shape, dtype=dtype, device="cpu")
+
+    ref = torch.sigmoid(x) * y
+    tri = sigmoid_and_mul(x, y)
+
+    torch.testing.assert_close(tri, ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("shape", [(512,), (1023,), (1024,)])
+def test_sigmoid_and_mul_backward(shape):
+    torch.manual_seed(0)
+    x = torch.randn(shape, dtype=torch.float32, device="cpu", requires_grad=True)
+    y = torch.randn(shape, dtype=torch.float32, device="cpu", requires_grad=True)
+
+    ref = torch.sigmoid(x) * y
+    grad_output = torch.randn_like(ref)
+    ref.backward(grad_output)
+    ref_dx = x.grad.clone()
+    ref_dy = y.grad.clone()
+
+    tri_dx, tri_dy = sigmoid_and_mul_backward(grad_output, x.detach(), y.detach())
+
+    torch.testing.assert_close(tri_dx, ref_dx, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(tri_dy, ref_dy, rtol=1e-4, atol=1e-4)

--- a/tasks/operators/README.md
+++ b/tasks/operators/README.md
@@ -1,0 +1,34 @@
+# Operator Task Files
+
+This directory contains Codex task descriptions used by the first
+Triton-RISCV operator workflow validation cycle.
+
+## Current Task Roles
+
+- `silu.md`: generated with `codex/generate_operator_task.py` and completed with
+  the successful validation result. This is the passing reference task.
+- `sigmoid_and_mul.md`: generated with `codex/generate_operator_task.py` for a
+  new fused operator implementation. The implementation and test passed on the
+  RISC-V validation server.
+- `relu_and_mul.md`: generated with `codex/generate_operator_task.py` for a
+  second new fused operator implementation. The implementation and test passed
+  on the RISC-V validation server.
+- `gelu.md`: validation and failure-triage task for GELU. This task records a
+  mixed result and identifies an MLIR lowering or translation failure involving
+  `linalg.generic`.
+- `erf.md`: validation and failure-isolation task for standalone `tl.math.erf`.
+  This task explains why GELU exact-mode failure is likely connected to math
+  lowering rather than GELU wrapper logic.
+- `vec_add.md`: baseline environment and compilation-flow task.
+
+## Implementation Scope
+
+The first validation cycle used existing repository operators and tests, then
+added `sigmoid_and_mul` and `relu_and_mul` as small generated fused operators.
+No compiler source file was modified. This was intentional: the observed GELU
+and ERF failures happen before runtime numerical comparison and are classified
+as compiler/lowering coverage issues.
+
+Future cycles can use the same generator and template to create true
+implementation tasks for missing operators. In that case, Codex should modify
+only the implementation and test files listed in the generated task.

--- a/tasks/operators/erf.md
+++ b/tasks/operators/erf.md
@@ -1,0 +1,127 @@
+# Operator Task: erf
+
+## Objective
+
+Use `erf` as a validation operator to isolate the math-lowering failure observed
+in GELU exact mode.
+
+## Operator Semantics
+
+`erf` computes the elementwise Gaussian error function.
+
+The existing implementation casts the input to `tl.float32` and stores
+`tl.math.erf(x_f32)` to the output tensor. The task includes both normal and
+in-place variants.
+
+## Reference Implementation
+
+- PyTorch reference:
+  - `torch.erf(x)`
+- Existing Triton or FlagGems reference:
+  - `python/examples/flaggems/erf.py`
+
+## Input and Output Contract
+
+- Inputs:
+  - `x`: input tensor
+- Outputs:
+  - `erf(x)` tensor with the same shape as `x`
+  - in-place output for `erf_`
+- Shapes:
+  - `(512,)`
+  - `(1023,)`
+  - `(1024,)`
+- Dtypes:
+  - `torch.float32`
+  - `torch.float16`
+  - `torch.float64`
+
+## Files to Inspect
+
+Codex should inspect these files before editing:
+
+- `docs/codex-operator-workflow.md`
+- `codex/templates/operator-task.md`
+- `python/examples/flaggems/erf.py`
+- `python/examples/flaggems/test_erf.py`
+- `python/examples/flaggems/gelu.py`
+- `python/examples/flaggems/test_gelu.py`
+
+## Files to Modify
+
+For the validation workflow, Codex should not modify implementation files unless
+the failure is proven to be an operator implementation issue.
+
+Allowed workflow files:
+
+- `tasks/operators/erf.md`
+- `experiment-results/operator-validation.md`
+- `docs/codex-operator-workflow.md`
+
+Implementation files are out of scope for the current validation pass:
+
+- `python/examples/flaggems/erf.py`
+- `python/examples/flaggems/test_erf.py`
+
+## Triton-RISCV Constraints
+
+- Keep the existing block-based elementwise pattern.
+- Keep masking explicit for tail elements.
+- Keep dtype conversion to `tl.float32` before `tl.math.erf`.
+- Do not introduce autotuning for this validation task.
+- Do not modify compiler internals under `lib/`, `include/`, or `backend/`
+  unless a separate compiler-fix task is created.
+
+## Failure Triage Focus
+
+The first validation attempt showed that all standalone erf cases fail during
+compilation:
+
+- Result: 18 failed
+- Log file: `test-logs/erf-20260603-010841.log`
+- Main error: `Dialect linalg not found for custom op linalg.generic`
+
+Codex should classify this as an MLIR lowering or translation failure. This
+result supports the GELU diagnosis because exact GELU depends on erf-like math
+lowering.
+
+## Build and Test Commands
+
+Set up the Triton-RISCV environment:
+
+```sh
+source scripts/triton-riscv-env.sh
+```
+
+Run the ERF test and save a log:
+
+```sh
+mkdir -p test-logs
+log="test-logs/erf-$(date +%Y%m%d-%H%M%S).log"
+python -m pytest -q python/examples/flaggems/test_erf.py -s 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+echo "exit=$status" | tee -a "$log"
+```
+
+## Success Criteria
+
+- Codex identifies that `erf` uses `tl.math.erf`.
+- Codex records the failure stage as MLIR lowering or translation, not numerical
+  correctness.
+- Codex records the `linalg.generic` issue.
+- Codex links the `erf` failure back to the GELU exact-mode failure.
+
+## Validation Attempts
+
+### Attempt 1: 2026-06-03
+
+- Test command: `python -m pytest -q python/examples/flaggems/test_erf.py -s`
+- Failure stage: MLIR lowering or translation
+- Compilation result: failed before runtime execution for all cases
+- Test result: 18 failed
+- Failure log: `test-logs/erf-20260603-010841.log`
+- Residual IR or dialect issue: generated MLIR contained `linalg.generic`
+- Likely failure reason: `tl.math.erf` lowering leaves linalg operations that
+  `mlir-translate --mlir-to-llvmir` cannot handle
+- Workflow improvement: use standalone math operators to isolate failures from
+  fused or wrapper operator logic

--- a/tasks/operators/gelu.md
+++ b/tasks/operators/gelu.md
@@ -1,0 +1,133 @@
+# Operator Task: gelu
+
+## Objective
+
+Use `gelu` as a validation operator to evaluate whether the Codex workflow can
+handle a multi-path elementwise activation and correctly diagnose compilation
+failures in Triton-RISCV.
+
+## Operator Semantics
+
+GELU computes the Gaussian Error Linear Unit.
+
+- `approximate="none"` uses the exact erf-based formula.
+- `approximate="tanh"` uses the tanh approximation.
+
+This task includes forward, in-place, backward, and dtype validation paths from
+the existing test file.
+
+## Reference Implementation
+
+- PyTorch reference:
+  - `torch.nn.functional.gelu(x, approximate=approximate)`
+- Existing Triton or FlagGems reference:
+  - `python/examples/flaggems/gelu.py`
+
+## Input and Output Contract
+
+- Inputs:
+  - `x`: input tensor
+  - `approximate`: GELU approximation mode, either `none` or `tanh`
+- Outputs:
+  - forward output tensor with the same shape as `x`
+  - in-place output for `gelu_`
+  - backward gradient output for `gelu_backward`
+- Shapes:
+  - `(512,)`, `(1023,)`, `(1024,)`
+  - backward shapes `(64, 128)` and `(128, 128)`
+- Dtypes:
+  - `torch.float16`
+  - `torch.float32`
+  - `torch.float64`
+
+## Files to Inspect
+
+Codex should inspect these files before editing:
+
+- `docs/codex-operator-workflow.md`
+- `codex/templates/operator-task.md`
+- `python/examples/flaggems/gelu.py`
+- `python/examples/flaggems/test_gelu.py`
+- `python/examples/flaggems/erf.py`
+- `python/examples/flaggems/test_erf.py`
+
+## Files to Modify
+
+For the validation workflow, Codex should not modify implementation files unless
+the failure is proven to be an operator implementation issue.
+
+Allowed workflow files:
+
+- `tasks/operators/gelu.md`
+- `experiment-results/operator-validation.md`
+- `docs/codex-operator-workflow.md`
+
+Implementation files are out of scope for the current validation pass:
+
+- `python/examples/flaggems/gelu.py`
+- `python/examples/flaggems/test_gelu.py`
+
+## Triton-RISCV Constraints
+
+- Keep existing block-based elementwise patterns.
+- Preserve both `none` and `tanh` approximation modes.
+- Keep dtype conversions explicit.
+- Do not introduce autotuning for this validation task.
+- Do not modify compiler internals under `lib/`, `include/`, or `backend/`
+  unless a separate compiler-fix task is created.
+
+## Failure Triage Focus
+
+The first validation attempt showed that `gelu` partially fails during
+compilation:
+
+- Result: 9 failed, 5 passed
+- Log file: `test-logs/gelu-20260602-235012.log`
+- Main error: `Dialect linalg not found for custom op linalg.generic`
+
+Codex should classify this as an MLIR lowering or translation failure. The
+failure is likely related to exact GELU or erf-like math lowering, because
+standalone `erf` shows the same `linalg.generic` failure.
+
+## Build and Test Commands
+
+Set up the Triton-RISCV environment:
+
+```sh
+source scripts/triton-riscv-env.sh
+```
+
+Run the GELU test and save a log:
+
+```sh
+mkdir -p test-logs
+log="test-logs/gelu-$(date +%Y%m%d-%H%M%S).log"
+python -m pytest -q python/examples/flaggems/test_gelu.py -s 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+echo "exit=$status" | tee -a "$log"
+```
+
+## Success Criteria
+
+- Codex identifies the GELU approximation modes and test coverage.
+- Codex distinguishes passing tanh-like paths from failing exact/erf-related
+  paths.
+- Codex records the failure stage as MLIR lowering or translation, not numerical
+  correctness.
+- Codex records the `linalg.generic` issue and links it to standalone `erf`
+  validation.
+
+## Validation Attempts
+
+### Attempt 1: 2026-06-02
+
+- Test command: `python -m pytest -q python/examples/flaggems/test_gelu.py -s`
+- Failure stage: MLIR lowering or translation
+- Compilation result: failed before runtime execution for several cases
+- Test result: 9 failed, 5 passed
+- Failure log: `test-logs/gelu-20260602-235012.log`
+- Residual IR or dialect issue: generated MLIR contained `linalg.generic`
+- Likely failure reason: exact GELU or related math lowering leaves linalg
+  operations that `mlir-translate --mlir-to-llvmir` cannot handle
+- Workflow improvement: add a failure triage step that checks for residual
+  unsupported dialect operations before asking Codex to edit operator code

--- a/tasks/operators/relu_and_mul.md
+++ b/tasks/operators/relu_and_mul.md
@@ -1,0 +1,153 @@
+# Operator Task: relu_and_mul
+
+## Objective
+
+Implement or complete the Triton-RISCV operator `relu_and_mul` using the
+workflow in `docs/codex-operator-workflow.md`.
+
+## Operator Semantics
+
+relu_and_mul computes torch.relu(x) * y elementwise. This validation task includes a generated forward kernel and a backward helper for dx and dy.
+
+## Reference Implementation
+
+- PyTorch reference:
+  - `torch.relu(x) * y`
+- Existing Triton or FlagGems reference:
+  - `python/examples/flaggems/relu_and_mul.py`
+
+## Input and Output Contract
+
+- Inputs:
+  - `x: input tensor; y: input tensor broadcastable to x`
+- Outputs:
+  - `output tensor with broadcasted shape; backward outputs dx and dy`
+- Shapes:
+  - `512, 1023, 1024`
+- Dtypes:
+  - `torch.float32 and torch.float16 for forward; torch.float32 for backward`
+
+## Files to Inspect
+
+Codex should inspect these files before editing code:
+
+- `README.md`
+- `docs/05-Operator Migration.md`
+- `python/examples/`
+- `python/examples/flaggems/`
+- `no additional files`
+
+## Files to Modify
+
+Codex may modify or add only the files needed for this operator:
+
+- `python/examples/flaggems/relu_and_mul.py`
+- `python/examples/flaggems/test_relu_and_mul.py`
+
+If other files appear necessary, explain why before modifying them.
+
+## Triton-RISCV Constraints
+
+Avoid unsupported or risky features unless the existing repository already uses
+them successfully for a similar operator.
+
+- Avoid autotuning in the initial implementation.
+- Prefer simple block-based elementwise kernels for first validation.
+- Compare against existing examples before introducing new Triton patterns.
+- Keep pointer arithmetic, masking, and dtype conversions explicit.
+
+## Environment Prerequisite Check
+
+Before running build or test commands, check that:
+
+- `../triton` exists, or `TRITON_DIR` points to a valid Triton checkout
+- `../buddy-mlir` exists, or `BUDDY_DIR` points to a valid Buddy MLIR checkout
+- `.venv` or the configured Python environment is available
+- `pytest` is available in the active environment
+- `scripts/triton-riscv-env.sh` can be sourced without path errors
+- the host architecture is supported by the selected build path
+
+If any item is missing, do not mark the operator as failed. Record an
+environment setup failure in the validation log.
+
+## Implementation Steps
+
+1. Read the reference implementation and existing nearby examples.
+2. Run the environment prerequisite check.
+3. Write or complete the Triton kernel.
+4. Add a Python wrapper if needed.
+5. Add or update pytest coverage.
+6. Compare results against the PyTorch reference implementation.
+7. Run the requested test command.
+8. Record the result in the validation log.
+
+## Failure Triage Steps
+
+If the test fails, classify the failure before modifying code:
+
+1. Environment failure: missing Triton checkout, Buddy checkout, Python
+   environment, pytest, or unsupported host architecture.
+2. Import failure: Python cannot import the implementation or test module.
+3. Triton compilation failure: JIT starts, but compilation fails before runtime.
+4. MLIR lowering or translation failure: generated MLIR cannot be translated to
+   LLVM IR.
+5. Runtime failure: compiled code launches but crashes or returns invalid data.
+6. Correctness failure: execution completes, but output differs from the PyTorch
+   reference.
+
+For MLIR lowering or translation failures, search the log for unsupported
+dialect operations. If the log contains `linalg.generic` or `Dialect linalg not
+found`, record the failure as a compiler/lowering coverage issue unless there is
+clear evidence that the operator implementation generated invalid semantics.
+
+Do not modify compiler internals or unrelated operator code as part of this task
+unless the task explicitly asks for a compiler fix.
+
+## Build and Test Commands
+
+Set up the environment:
+
+```sh
+source scripts/triton-riscv-env.sh
+```
+
+Run the relevant test:
+
+```sh
+python -m pytest -q python/examples/flaggems/test_relu_and_mul.py -s
+```
+
+If the implementation requires a rebuild, run:
+
+```sh
+scripts/rebuild-triton-riscv.sh
+```
+
+## Success Criteria
+
+- The operator implementation matches the stated semantics.
+- The test compares against a PyTorch reference implementation.
+- The relevant pytest command passes.
+- Any unsupported cases are documented.
+
+## Validation Attempts
+
+Append a new attempt entry after each validation run. Do not replace older
+attempts.
+
+### Attempt 1: 2026-06-03
+
+- Operator: relu_and_mul
+- Task file: `tasks/operators/relu_and_mul.md`
+- Implementation files:
+  - `python/examples/flaggems/relu_and_mul.py`
+  - `python/examples/flaggems/test_relu_and_mul.py`
+- Test command: `python -m pytest -q python/examples/flaggems/test_relu_and_mul.py -s`
+- Failure stage: none
+- Compilation result: passed
+- Test result: 9 passed
+- Failure log: none
+- Residual IR or dialect issue: none observed
+- Likely failure reason: not applicable
+- Workflow improvement: the generated task flow works for another simple fused
+  elementwise operator using supported max/mul lowering

--- a/tasks/operators/sigmoid_and_mul.md
+++ b/tasks/operators/sigmoid_and_mul.md
@@ -1,0 +1,153 @@
+# Operator Task: sigmoid_and_mul
+
+## Objective
+
+Implement or complete the Triton-RISCV operator `sigmoid_and_mul` using the
+workflow in `docs/codex-operator-workflow.md`.
+
+## Operator Semantics
+
+sigmoid_and_mul computes torch.sigmoid(x) * y elementwise. This validation task includes a generated forward kernel and a backward helper for dx and dy.
+
+## Reference Implementation
+
+- PyTorch reference:
+  - `torch.sigmoid(x) * y`
+- Existing Triton or FlagGems reference:
+  - `python/examples/flaggems/sigmoid_and_mul.py`
+
+## Input and Output Contract
+
+- Inputs:
+  - `x: input tensor; y: input tensor broadcastable to x`
+- Outputs:
+  - `output tensor with broadcasted shape; backward outputs dx and dy`
+- Shapes:
+  - `512, 1023, 1024`
+- Dtypes:
+  - `torch.float32 and torch.float16 for forward; torch.float32 for backward`
+
+## Files to Inspect
+
+Codex should inspect these files before editing code:
+
+- `README.md`
+- `docs/05-Operator Migration.md`
+- `python/examples/`
+- `python/examples/flaggems/`
+- `no additional files`
+
+## Files to Modify
+
+Codex may modify or add only the files needed for this operator:
+
+- `python/examples/flaggems/sigmoid_and_mul.py`
+- `python/examples/flaggems/test_sigmoid_and_mul.py`
+
+If other files appear necessary, explain why before modifying them.
+
+## Triton-RISCV Constraints
+
+Avoid unsupported or risky features unless the existing repository already uses
+them successfully for a similar operator.
+
+- Avoid autotuning in the initial implementation.
+- Prefer simple block-based elementwise kernels for first validation.
+- Compare against existing examples before introducing new Triton patterns.
+- Keep pointer arithmetic, masking, and dtype conversions explicit.
+
+## Environment Prerequisite Check
+
+Before running build or test commands, check that:
+
+- `../triton` exists, or `TRITON_DIR` points to a valid Triton checkout
+- `../buddy-mlir` exists, or `BUDDY_DIR` points to a valid Buddy MLIR checkout
+- `.venv` or the configured Python environment is available
+- `pytest` is available in the active environment
+- `scripts/triton-riscv-env.sh` can be sourced without path errors
+- the host architecture is supported by the selected build path
+
+If any item is missing, do not mark the operator as failed. Record an
+environment setup failure in the validation log.
+
+## Implementation Steps
+
+1. Read the reference implementation and existing nearby examples.
+2. Run the environment prerequisite check.
+3. Write or complete the Triton kernel.
+4. Add a Python wrapper if needed.
+5. Add or update pytest coverage.
+6. Compare results against the PyTorch reference implementation.
+7. Run the requested test command.
+8. Record the result in the validation log.
+
+## Failure Triage Steps
+
+If the test fails, classify the failure before modifying code:
+
+1. Environment failure: missing Triton checkout, Buddy checkout, Python
+   environment, pytest, or unsupported host architecture.
+2. Import failure: Python cannot import the implementation or test module.
+3. Triton compilation failure: JIT starts, but compilation fails before runtime.
+4. MLIR lowering or translation failure: generated MLIR cannot be translated to
+   LLVM IR.
+5. Runtime failure: compiled code launches but crashes or returns invalid data.
+6. Correctness failure: execution completes, but output differs from the PyTorch
+   reference.
+
+For MLIR lowering or translation failures, search the log for unsupported
+dialect operations. If the log contains `linalg.generic` or `Dialect linalg not
+found`, record the failure as a compiler/lowering coverage issue unless there is
+clear evidence that the operator implementation generated invalid semantics.
+
+Do not modify compiler internals or unrelated operator code as part of this task
+unless the task explicitly asks for a compiler fix.
+
+## Build and Test Commands
+
+Set up the environment:
+
+```sh
+source scripts/triton-riscv-env.sh
+```
+
+Run the relevant test:
+
+```sh
+python -m pytest -q python/examples/flaggems/test_sigmoid_and_mul.py -s
+```
+
+If the implementation requires a rebuild, run:
+
+```sh
+scripts/rebuild-triton-riscv.sh
+```
+
+## Success Criteria
+
+- The operator implementation matches the stated semantics.
+- The test compares against a PyTorch reference implementation.
+- The relevant pytest command passes.
+- Any unsupported cases are documented.
+
+## Validation Attempts
+
+Append a new attempt entry after each validation run. Do not replace older
+attempts.
+
+### Attempt 1: 2026-06-03
+
+- Operator: sigmoid_and_mul
+- Task file: `tasks/operators/sigmoid_and_mul.md`
+- Implementation files:
+  - `python/examples/flaggems/sigmoid_and_mul.py`
+  - `python/examples/flaggems/test_sigmoid_and_mul.py`
+- Test command: `python -m pytest -q python/examples/flaggems/test_sigmoid_and_mul.py -s`
+- Failure stage: none
+- Compilation result: passed
+- Test result: 9 passed
+- Failure log: none
+- Residual IR or dialect issue: none observed
+- Likely failure reason: not applicable
+- Workflow improvement: the generated task flow is sufficient for a simple
+  fused elementwise operator that uses supported exp-based math lowering

--- a/tasks/operators/silu.md
+++ b/tasks/operators/silu.md
@@ -1,0 +1,151 @@
+# Operator Task: silu
+
+## Objective
+
+Implement or complete the Triton-RISCV operator `silu` using the
+workflow in `docs/codex-operator-workflow.md`.
+
+## Operator Semantics
+
+SiLU computes x / (1 + exp(-x)). This validation task uses the existing forward operator and pytest reference comparison.
+
+## Reference Implementation
+
+- PyTorch reference:
+  - `torch.nn.functional.silu(x)`
+- Existing Triton or FlagGems reference:
+  - `python/examples/flaggems/silu.py`
+
+## Input and Output Contract
+
+- Inputs:
+  - `x: input tensor`
+- Outputs:
+  - `output tensor with the same shape as x`
+- Shapes:
+  - `512, 1023, 1024`
+- Dtypes:
+  - `torch.float32, torch.float16, torch.float64`
+
+## Files to Inspect
+
+Codex should inspect these files before editing code:
+
+- `README.md`
+- `docs/05-Operator Migration.md`
+- `python/examples/`
+- `python/examples/flaggems/`
+- `no additional files`
+
+## Files to Modify
+
+Codex may modify or add only the files needed for this operator:
+
+- `python/examples/flaggems/silu.py`
+- `python/examples/flaggems/test_silu.py`
+
+If other files appear necessary, explain why before modifying them.
+
+## Triton-RISCV Constraints
+
+Avoid unsupported or risky features unless the existing repository already uses
+them successfully for a similar operator.
+
+- Avoid autotuning in the initial implementation.
+- Prefer simple block-based elementwise kernels for first validation.
+- Compare against existing examples before introducing new Triton patterns.
+- Keep pointer arithmetic, masking, and dtype conversions explicit.
+
+## Environment Prerequisite Check
+
+Before running build or test commands, check that:
+
+- `../triton` exists, or `TRITON_DIR` points to a valid Triton checkout
+- `../buddy-mlir` exists, or `BUDDY_DIR` points to a valid Buddy MLIR checkout
+- `.venv` or the configured Python environment is available
+- `pytest` is available in the active environment
+- `scripts/triton-riscv-env.sh` can be sourced without path errors
+- the host architecture is supported by the selected build path
+
+If any item is missing, do not mark the operator as failed. Record an
+environment setup failure in the validation log.
+
+## Implementation Steps
+
+1. Read the reference implementation and existing nearby examples.
+2. Run the environment prerequisite check.
+3. Write or complete the Triton kernel.
+4. Add a Python wrapper if needed.
+5. Add or update pytest coverage.
+6. Compare results against the PyTorch reference implementation.
+7. Run the requested test command.
+8. Record the result in the validation log.
+
+## Failure Triage Steps
+
+If the test fails, classify the failure before modifying code:
+
+1. Environment failure: missing Triton checkout, Buddy checkout, Python
+   environment, pytest, or unsupported host architecture.
+2. Import failure: Python cannot import the implementation or test module.
+3. Triton compilation failure: JIT starts, but compilation fails before runtime.
+4. MLIR lowering or translation failure: generated MLIR cannot be translated to
+   LLVM IR.
+5. Runtime failure: compiled code launches but crashes or returns invalid data.
+6. Correctness failure: execution completes, but output differs from the PyTorch
+   reference.
+
+For MLIR lowering or translation failures, search the log for unsupported
+dialect operations. If the log contains `linalg.generic` or `Dialect linalg not
+found`, record the failure as a compiler/lowering coverage issue unless there is
+clear evidence that the operator implementation generated invalid semantics.
+
+Do not modify compiler internals or unrelated operator code as part of this task
+unless the task explicitly asks for a compiler fix.
+
+## Build and Test Commands
+
+Set up the environment:
+
+```sh
+source scripts/triton-riscv-env.sh
+```
+
+Run the relevant test:
+
+```sh
+python -m pytest -q python/examples/flaggems/test_silu.py -s
+```
+
+If the implementation requires a rebuild, run:
+
+```sh
+scripts/rebuild-triton-riscv.sh
+```
+
+## Success Criteria
+
+- The operator implementation matches the stated semantics.
+- The test compares against a PyTorch reference implementation.
+- The relevant pytest command passes.
+- Any unsupported cases are documented.
+
+## Validation Attempts
+
+Append a new attempt entry after each validation run. Do not replace older
+attempts.
+
+### Attempt 1: 2026-06-02
+
+- Operator: silu
+- Task file: `tasks/operators/silu.md`
+- Implementation files: `python/examples/flaggems/silu.py`
+- Test command: `python -m pytest -q python/examples/flaggems/test_silu.py -s`
+- Failure stage: none
+- Compilation result: passed
+- Test result: 10 passed
+- Failure log: none
+- Residual IR or dialect issue: none observed
+- Likely failure reason: not applicable
+- Workflow improvement: keep this operator as a passing reference case for
+  simple elementwise activation validation

--- a/tasks/operators/vec_add.md
+++ b/tasks/operators/vec_add.md
@@ -1,0 +1,107 @@
+# Operator Task: vec_add
+
+## Objective
+
+Use vec_add as a simple validation operator to check whether Codex can understand the basic Triton-RISCV elementwise kernel pattern, identify the PyTorch reference comparison, and run a minimal operator validation flow.
+
+## Operator Semantics
+
+vec_add computes the elementwise sum of two input tensors.
+
+For each element, it computes `output = x + y`.
+
+This validation task includes the forward kernel only.
+
+## Reference Implementation
+
+- PyTorch reference:
+  - `x + y`
+  - The reference comparison is in `python/examples/test_vec_add.py`.
+- Existing Triton reference:
+  - `python/examples/test_vec_add.py`
+
+## Input and Output Contract
+
+- Inputs:
+  - `x`: input tensor
+  - `y`: input tensor with the same shape as `x`
+- Outputs:
+  - `output`: tensor with the same shape as `x` and `y`
+- Shapes:
+  - one-dimensional tensors are used by the existing example
+  - the example uses a large vector size for validation and benchmarking
+- Dtypes:
+  - `torch.float32` in the benchmark path
+
+## Files to Inspect
+
+Codex should inspect these files before editing:
+
+- `docs/codex-operator-workflow.md`
+- `codex/templates/operator-task.md`
+- `docs/05-Operator Migration.md`
+- `python/examples/test_vec_add.py`
+- `README.md`
+
+## Files to Modify
+
+Codex should not modify the implementation for the first validation pass unless it finds a clear issue.
+
+Allowed files for this validation task:
+
+- `tasks/operators/vec_add.md`
+- `python/examples/test_vec_add.py`
+
+## Triton-RISCV Constraints
+
+- Use the existing block-based elementwise kernel pattern.
+- Keep `BLOCK_SIZE` explicit.
+- Use `tl.arange`, `tl.load`, `tl.store`, and `mask` for boundary handling.
+- Do not introduce autotuning for this validation task.
+- Do not modify compiler internals under `lib/` or `include/`.
+
+## Environment Prerequisite Check
+
+Before running the test command, check that `../triton` and `../buddy-mlir` exist or that `TRITON_DIR` and `BUDDY_DIR` point to valid checkouts. Also check that the Python environment provides `pytest` and that `scripts/triton-riscv-env.sh` can be sourced without path errors. Confirm that the host architecture is supported by the selected build path.
+
+If these prerequisites are missing, record an environment setup failure instead of marking `vec_add` as an operator implementation failure.
+
+## Implementation Steps
+
+1. Read `python/examples/test_vec_add.py`.
+2. Run the environment prerequisite check.
+3. Identify the forward formula `output = x + y`.
+4. Confirm that the PyTorch reference is `x + y`.
+5. Confirm that the kernel uses block offsets and mask-based boundary handling.
+6. Run or report the relevant pytest command.
+7. Record the validation result and any workflow issue found.
+
+## Build and Test Commands
+
+Set up the Triton-RISCV environment by sourcing `scripts/triton-riscv-env.sh`.
+
+Run the vector add test with `pytest python/examples/test_vec_add.py -v`.
+
+If the local build is stale or the operator does not compile, rebuild Triton-RISCV with `scripts/rebuild-triton-riscv.sh` and then run the pytest command again.
+
+## Success Criteria
+
+- Codex correctly identifies the operator formula.
+- Codex identifies the block-based Triton kernel structure.
+- Codex identifies the PyTorch reference comparison.
+- The relevant pytest command passes.
+- Any failure is recorded with the failing command and likely reason.
+
+## Validation Attempts
+
+Append a new attempt entry after each validation run. Do not replace older attempts.
+
+### Attempt 1: 2026-06-02
+
+- Test command: `python -m pytest -q python/examples/test_vec_add.py -s`
+- Compilation result: passed through Triton-RISCV JIT compilation and execution
+- Test result: 1 passed
+- Failure log: none
+- Likely failure reason: not applicable
+- Workflow improvement: keep `vec_add` as the baseline check for environment,
+  backend registration, compilation, execution, and PyTorch reference comparison


### PR DESCRIPTION
Add a Codex-compatible operator generation and compilation workflow for Triton-RISCV.

Includes:
- reusable workflow documentation
- task template and task generator
- operator task contexts
- two generated fused operators: sigmoid_and_mul and relu_and_mul
- validation records and final summary

## Validation

- sigmoid_and_mul: 9 passed
- relu_and_mul: 9 passed
- vec_add: 1 passed
- silu: 10 passed
- gelu/erf failures recorded as MLIR lowering / translation issues involving linalg.generic