### PR TITLE
Add ExpandFloat8Conversions pass and enable RISC-V FP8 support

### DIFF
--- a/backend/compiler.py
+++ b/backend/compiler.py
@@ -225,6 +225,7 @@ def _ttsharedir_to_vectorir(ttsharedir: str):
     with tempfile.TemporaryDirectory() as tmpdir:
         ttshared_path = os.path.join(tmpdir, "ttshared.mlir")
         vector_path = os.path.join(tmpdir, "vector.mlir")
+        fp8_expanded_vector_path = os.path.join(tmpdir, "vector-fp8-expanded.mlir")
         Path(ttshared_path).write_text(ttsharedir)
         buddy_opt_path = _get_buddy_opt_path()
         subprocess.check_call(
@@ -254,9 +255,25 @@ def _ttsharedir_to_vectorir(ttsharedir: str):
 def _vectorir_to_llir(vectorir: str):
     with tempfile.TemporaryDirectory() as tmpdir:
         vector_path = os.path.join(tmpdir, "vector.mlir")
+        fp8_expanded_vector_path = os.path.join(tmpdir, "vector-fp8-expanded.mlir")
         llmlir_path = os.path.join(tmpdir, "ll.mlir")
         llir_path = os.path.join(tmpdir, "ll.ir")
         Path(vector_path).write_text(vectorir)
+        if "f8E4M3FN" in vectorir:
+            triton_shared_opt_path = _get_triton_shared_opt_path()
+            subprocess.check_call(
+                [
+                    triton_shared_opt_path,
+                    vector_path,
+                    "--expand-float8-conversions",
+                    "--canonicalize",
+                    "--mlir-print-debuginfo",
+                    "-o",
+                    fp8_expanded_vector_path,
+                ]
+            )
+            _dump_ir_if_needed([fp8_expanded_vector_path])
+            vector_path = fp8_expanded_vector_path
         buddy_opt_path = _get_buddy_opt_path()
         # TritonShared-MLIR to LLVM-MLIR
         subprocess.check_call(
@@ -433,10 +450,11 @@ class CPUOptions:
     extern_libs = None
     cluster_dims: tuple = (1, 1, 1)
     shared: bool = False
-    # Disable FP8 here since this is a sample CPU backend.
-    # Target specific backends can eanble it with supported types.
-    supported_fp8_dtypes: Tuple[str] = ()
-    allow_fp8e4nv: bool = False
+    # The RISC-V backend supports fp8_e4m3fn storage/conversion through
+    # Triton's fp8e4nv IR type. Keep the list explicit so unsupported fp8
+    # variants still fail at frontend type legalization.
+    supported_fp8_dtypes: Tuple[str] = ("fp8e4nv",)
+    allow_fp8e4nv: bool = True
     allowed_dot_input_precisions: Tuple[str] = ("ieee",)
     sanitize_overflow: bool = True
 

--- a/backend/include/ExecutionEngine/CRunnerUtils.cpp
+++ b/backend/include/ExecutionEngine/CRunnerUtils.cpp
@@ -29,8 +29,10 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <random>
 #include <string.h>
 
@@ -38,6 +40,15 @@
 
 namespace {
 template <typename V> void stdSort(uint64_t n, V *p) { std::sort(p, p + n); }
+
+uint32_t roundToNearestEven(float value) {
+  float floored = std::floor(value);
+  uint32_t rounded = static_cast<uint32_t>(floored);
+  float fraction = value - floored;
+  if (fraction > 0.5f || (fraction == 0.5f && (rounded & 1u)))
+    ++rounded;
+  return rounded;
+}
 
 } // namespace
 
@@ -110,6 +121,61 @@ extern "C" void memrefCopy(int64_t elemSize, UnrankedMemRefType<char> *srcArg,
       writeIndex -= dst.sizes[axis] * dstStrides[axis];
     }
   }
+}
+
+extern "C" float __triton_shared_fp8e4nv_to_f32(uint8_t bits) {
+  uint8_t sign = bits & 0x80u;
+  uint8_t exponent = (bits >> 3) & 0x0fu;
+  uint8_t mantissa = bits & 0x07u;
+
+  float value;
+  if (exponent == 0) {
+    value = std::ldexp(static_cast<float>(mantissa), -9);
+  } else if (exponent == 0x0f && mantissa == 0x07) {
+    value = std::numeric_limits<float>::quiet_NaN();
+  } else {
+    value = std::ldexp(static_cast<float>(8u + mantissa), exponent - 10);
+  }
+
+  return sign ? -value : value;
+}
+
+extern "C" uint8_t __triton_shared_f32_to_fp8e4nv(float value) {
+  uint8_t sign = std::signbit(value) ? 0x80u : 0u;
+  float magnitude = std::fabs(value);
+
+  if (std::isnan(value) || std::isinf(value) || magnitude > 464.0f)
+    return sign | 0x7fu;
+  if (magnitude == 0.0f)
+    return sign;
+
+  constexpr float minNormal = 0.015625f; // 2^-6
+  if (magnitude < minNormal) {
+    uint32_t subnormal = roundToNearestEven(magnitude * 512.0f);
+    if (subnormal > 8u)
+      subnormal = 8u;
+    return sign | static_cast<uint8_t>(subnormal);
+  }
+
+  int frexpExponent = 0;
+  std::frexp(magnitude, &frexpExponent);
+  int exponent = frexpExponent - 1;
+  uint32_t significand =
+      roundToNearestEven(std::ldexp(magnitude, 3 - exponent));
+  if (significand == 16u) {
+    significand = 8u;
+    ++exponent;
+  }
+
+  int encodedExponent = exponent + 7;
+  if (encodedExponent >= 16)
+    return sign | 0x7fu;
+
+  uint32_t mantissa = significand - 8u;
+  if (encodedExponent == 15 && mantissa >= 7u)
+    return sign | 0x7fu;
+
+  return sign | static_cast<uint8_t>((encodedExponent << 3) | mantissa);
 }
 
 /// Prints GFLOPS rating.

--- a/include/triton-shared/Transform/CMakeLists.txt
+++ b/include/triton-shared/Transform/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(AddLLVMDebugInfo)
+add_subdirectory(ExpandFloat8Conversions)

--- a/include/triton-shared/Transform/ExpandFloat8Conversions/CMakeLists.txt
+++ b/include/triton-shared/Transform/ExpandFloat8Conversions/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls --name ExpandFloat8Conversions)
+add_public_tablegen_target(ExpandFloat8ConversionsTransformPassIncGen)

--- a/include/triton-shared/Transform/ExpandFloat8Conversions/ExpandFloat8Conversions.h
+++ b/include/triton-shared/Transform/ExpandFloat8Conversions/ExpandFloat8Conversions.h
@@ -1,0 +1,15 @@
+#ifndef TRITON_SHARED_TRANSFORM_EXPAND_FLOAT8_CONVERSIONS_H
+#define TRITON_SHARED_TRANSFORM_EXPAND_FLOAT8_CONVERSIONS_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createExpandFloat8ConversionsPass();
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/include/triton-shared/Transform/ExpandFloat8Conversions/Passes.h
+++ b/include/triton-shared/Transform/ExpandFloat8Conversions/Passes.h
@@ -1,0 +1,15 @@
+#ifndef EXPAND_FLOAT8_CONVERSIONS_TRANSFORM_PASSES_H
+#define EXPAND_FLOAT8_CONVERSIONS_TRANSFORM_PASSES_H
+
+#include "triton-shared/Transform/ExpandFloat8Conversions/ExpandFloat8Conversions.h"
+
+namespace mlir {
+namespace triton {
+
+#define GEN_PASS_REGISTRATION
+#include "triton-shared/Transform/ExpandFloat8Conversions/Passes.h.inc"
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/include/triton-shared/Transform/ExpandFloat8Conversions/Passes.td
+++ b/include/triton-shared/Transform/ExpandFloat8Conversions/Passes.td
@@ -1,0 +1,12 @@
+#ifndef EXPAND_FLOAT8_CONVERSIONS_TRANSFORM_PASSES
+#define EXPAND_FLOAT8_CONVERSIONS_TRANSFORM_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def ExpandFloat8Conversions
+    : Pass<"expand-float8-conversions", "mlir::ModuleOp"> {
+  let summary = "Expand f8E4M3FN conversions to runtime helper calls";
+  let constructor = "triton::createExpandFloat8ConversionsPass()";
+}
+
+#endif

--- a/lib/Transform/CMakeLists.txt
+++ b/lib/Transform/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(AddLLVMDebugInfo)
+add_subdirectory(ExpandFloat8Conversions)

--- a/lib/Transform/ExpandFloat8Conversions/CMakeLists.txt
+++ b/lib/Transform/ExpandFloat8Conversions/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_triton_library(ExpandFloat8Conversions
+  ExpandFloat8ConversionsPass.cpp
+
+  DEPENDS
+  ExpandFloat8ConversionsTransformPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRArithDialect
+  MLIRFuncDialect
+  MLIRIR
+  MLIRLLVMDialect
+  MLIRPass
+  MLIRVectorDialect
+)

--- a/lib/Transform/ExpandFloat8Conversions/ExpandFloat8ConversionsPass.cpp
+++ b/lib/Transform/ExpandFloat8Conversions/ExpandFloat8ConversionsPass.cpp
@@ -1,0 +1,270 @@
+#include "triton-shared/Transform/ExpandFloat8Conversions/ExpandFloat8Conversions.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
+
+#define DEBUG_TYPE "expand-float8-conversions"
+
+using namespace mlir;
+using namespace triton;
+
+#define GEN_PASS_CLASSES
+#include "triton-shared/Transform/ExpandFloat8Conversions/Passes.h.inc"
+
+namespace {
+
+constexpr StringLiteral kFp8ToF32Name = "__triton_shared_fp8e4nv_to_f32";
+constexpr StringLiteral kF32ToFp8Name = "__triton_shared_f32_to_fp8e4nv";
+
+static FlatSymbolRefAttr getOrCreateHelper(ModuleOp module, StringRef name,
+                                           TypeRange inputs, TypeRange results,
+                                           OpBuilder &builder) {
+  if (!module.lookupSymbol<func::FuncOp>(name)) {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(module.getBody());
+    auto functionType = builder.getFunctionType(inputs, results);
+    auto func =
+        builder.create<func::FuncOp>(module.getLoc(), name, functionType);
+    func.setPrivate();
+  }
+
+  return SymbolRefAttr::get(builder.getContext(), name);
+}
+
+static bool isFp8E4M3FN(Type type) { return isa<Float8E4M3FNType>(type); }
+
+static bool isFloat(Type type) { return isa<FloatType>(type); }
+
+static bool isFixedVectorOf(VectorType type, Type elementType) {
+  return type && !type.isScalable() && type.getElementType() == elementType;
+}
+
+static bool isScalarOrFixedVectorOf(Type type, Type elementType) {
+  if (type == elementType)
+    return true;
+  auto vectorType = dyn_cast<VectorType>(type);
+  return vectorType && isFixedVectorOf(vectorType, elementType);
+}
+
+static bool isScalarOrFixedVectorOfFloat(Type type) {
+  if (isFloat(type))
+    return true;
+  auto vectorType = dyn_cast<VectorType>(type);
+  return vectorType && !vectorType.isScalable() &&
+         isFloat(vectorType.getElementType());
+}
+
+static bool hasSameFixedVectorShape(Type lhs, Type rhs) {
+  auto lhsVector = dyn_cast<VectorType>(lhs);
+  auto rhsVector = dyn_cast<VectorType>(rhs);
+  if (!lhsVector || !rhsVector)
+    return !lhsVector && !rhsVector;
+  return !lhsVector.isScalable() && !rhsVector.isScalable() &&
+         lhsVector.getShape() == rhsVector.getShape();
+}
+
+static Value castToF32(Location loc, Value value, Type f32Type,
+                       IRRewriter &rewriter) {
+  Type type = value.getType();
+  if (type == f32Type)
+    return value;
+  return rewriter.create<arith::ExtFOp>(loc, f32Type, value);
+}
+
+static Value castFromF32(Location loc, Value value, Type targetType,
+                         IRRewriter &rewriter) {
+  if (value.getType() == targetType)
+    return value;
+  return rewriter.create<arith::TruncFOp>(loc, targetType, value);
+}
+
+static Value createF32ToFp8Scalar(Location loc, Value f32,
+                                  FlatSymbolRefAttr helper, Type i8Type,
+                                  IRRewriter &rewriter) {
+  auto call = rewriter.create<func::CallOp>(loc, helper, i8Type, f32);
+  return rewriter.create<arith::BitcastOp>(
+      loc, Float8E4M3FNType::get(i8Type.getContext()), call.getResult(0));
+}
+
+static Value createFp8ToF32Scalar(Location loc, Value fp8,
+                                  FlatSymbolRefAttr helper, Type i8Type,
+                                  Type f32Type, IRRewriter &rewriter) {
+  Value bits = rewriter.create<arith::BitcastOp>(loc, i8Type, fp8);
+  auto call = rewriter.create<func::CallOp>(loc, helper, f32Type, bits);
+  return call.getResult(0);
+}
+
+static Value createFpToFp8Scalar(Location loc, Value value,
+                                 FlatSymbolRefAttr helper, Type i8Type,
+                                 Type f32Type, IRRewriter &rewriter) {
+  Value f32 = castToF32(loc, value, f32Type, rewriter);
+  return createF32ToFp8Scalar(loc, f32, helper, i8Type, rewriter);
+}
+
+static Value createFp8ToFpScalar(Location loc, Value fp8,
+                                 FlatSymbolRefAttr helper, Type i8Type,
+                                 Type f32Type, Type targetType,
+                                 IRRewriter &rewriter) {
+  Value f32 = createFp8ToF32Scalar(loc, fp8, helper, i8Type, f32Type, rewriter);
+  return castFromF32(loc, f32, targetType, rewriter);
+}
+
+static Value createZeroVector(Location loc, VectorType vectorType, Type i8Type,
+                              Type f32Type, IRRewriter &rewriter) {
+  Type elementType = vectorType.getElementType();
+  Value zero;
+  if (isFloat(elementType)) {
+    auto floatType = cast<FloatType>(elementType);
+    zero = rewriter.create<arith::ConstantFloatOp>(
+        loc, floatType, APFloat::getZero(floatType.getFloatSemantics()));
+  } else {
+    assert(isFp8E4M3FN(elementType) && "unexpected fp8 expansion vector type");
+    Value zeroBits = rewriter.create<arith::ConstantIntOp>(loc, i8Type, 0);
+    zero = rewriter.create<arith::BitcastOp>(loc, elementType, zeroBits);
+  }
+  return rewriter.create<vector::SplatOp>(loc, vectorType, zero);
+}
+
+static Value expandFpToFp8(Location loc, Value fpValue, Type resultType,
+                           FlatSymbolRefAttr helper, Type i8Type, Type f32Type,
+                           IRRewriter &rewriter) {
+  auto vectorType = dyn_cast<VectorType>(resultType);
+  if (!vectorType)
+    return createFpToFp8Scalar(loc, fpValue, helper, i8Type, f32Type, rewriter);
+
+  int64_t numElements = vectorType.getNumElements();
+  auto v1dType = VectorType::get({numElements}, vectorType.getElementType());
+  auto v1dInputType = VectorType::get(
+      {numElements}, cast<VectorType>(fpValue.getType()).getElementType());
+
+  Value input1d =
+      rewriter.create<vector::ShapeCastOp>(loc, v1dInputType, fpValue);
+  Value result1d = createZeroVector(loc, v1dType, i8Type, f32Type, rewriter);
+
+  Value lb = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value ub = rewriter.create<arith::ConstantIndexOp>(loc, numElements);
+  Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+  auto forOp = rewriter.create<scf::ForOp>(
+      loc, lb, ub, step, ValueRange{result1d},
+      [&](OpBuilder &b, Location l, Value iv, ValueRange iterArgs) {
+        Value scalar = b.create<vector::ExtractElementOp>(l, input1d, iv);
+        Value converted =
+            createFpToFp8Scalar(l, scalar, helper, i8Type, f32Type, rewriter);
+        Value updated =
+            b.create<vector::InsertElementOp>(l, converted, iterArgs[0], iv);
+        b.create<scf::YieldOp>(l, updated);
+      });
+
+  return rewriter.create<vector::ShapeCastOp>(loc, vectorType,
+                                              forOp.getResult(0));
+}
+
+static Value expandFp8ToFp(Location loc, Value fp8Value, Type resultType,
+                           FlatSymbolRefAttr helper, Type i8Type, Type f32Type,
+                           IRRewriter &rewriter) {
+  auto vectorType = dyn_cast<VectorType>(resultType);
+  if (!vectorType)
+    return createFp8ToFpScalar(loc, fp8Value, helper, i8Type, f32Type,
+                               resultType, rewriter);
+
+  int64_t numElements = vectorType.getNumElements();
+  auto v1dType = VectorType::get({numElements}, vectorType.getElementType());
+  auto v1dInputType = VectorType::get(
+      {numElements}, cast<VectorType>(fp8Value.getType()).getElementType());
+
+  Value input1d =
+      rewriter.create<vector::ShapeCastOp>(loc, v1dInputType, fp8Value);
+  Value result1d = createZeroVector(loc, v1dType, i8Type, f32Type, rewriter);
+
+  Value lb = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value ub = rewriter.create<arith::ConstantIndexOp>(loc, numElements);
+  Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+  auto forOp = rewriter.create<scf::ForOp>(
+      loc, lb, ub, step, ValueRange{result1d},
+      [&](OpBuilder &b, Location l, Value iv, ValueRange iterArgs) {
+        Value scalar = b.create<vector::ExtractElementOp>(l, input1d, iv);
+        Value converted =
+            createFp8ToFpScalar(l, scalar, helper, i8Type, f32Type,
+                                v1dType.getElementType(), rewriter);
+        Value updated =
+            b.create<vector::InsertElementOp>(l, converted, iterArgs[0], iv);
+        b.create<scf::YieldOp>(l, updated);
+      });
+
+  return rewriter.create<vector::ShapeCastOp>(loc, vectorType,
+                                              forOp.getResult(0));
+}
+
+class ExpandFloat8ConversionsPass
+    : public ExpandFloat8ConversionsBase<ExpandFloat8ConversionsPass> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, func::FuncDialect, LLVM::LLVMDialect,
+                    scf::SCFDialect, vector::VectorDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *context = &getContext();
+    auto i8Type = IntegerType::get(context, 8);
+    auto f32Type = Float32Type::get(context);
+
+    SmallVector<arith::ExtFOp> fp8ExtOps;
+    SmallVector<arith::TruncFOp> fp8TruncOps;
+    module.walk([&](arith::ExtFOp op) {
+      if (isScalarOrFixedVectorOf(op.getOperand().getType(),
+                                  Float8E4M3FNType::get(context)) &&
+          isScalarOrFixedVectorOfFloat(op.getType()) &&
+          hasSameFixedVectorShape(op.getOperand().getType(), op.getType()))
+        fp8ExtOps.push_back(op);
+    });
+    module.walk([&](arith::TruncFOp op) {
+      if (isScalarOrFixedVectorOfFloat(op.getOperand().getType()) &&
+          isScalarOrFixedVectorOf(op.getType(),
+                                  Float8E4M3FNType::get(context)) &&
+          hasSameFixedVectorShape(op.getOperand().getType(), op.getType()))
+        fp8TruncOps.push_back(op);
+    });
+
+    if (fp8ExtOps.empty() && fp8TruncOps.empty())
+      return;
+
+    OpBuilder builder(context);
+    auto fp8ToF32 =
+        getOrCreateHelper(module, kFp8ToF32Name, {i8Type}, {f32Type}, builder);
+    auto f32ToFp8 =
+        getOrCreateHelper(module, kF32ToFp8Name, {f32Type}, {i8Type}, builder);
+
+    IRRewriter rewriter(context);
+    for (arith::ExtFOp op : fp8ExtOps) {
+      rewriter.setInsertionPoint(op);
+      Location loc = op.getLoc();
+      rewriter.replaceOp(op,
+                         expandFp8ToFp(loc, op.getOperand(), op.getType(),
+                                       fp8ToF32, i8Type, f32Type, rewriter));
+    }
+
+    for (arith::TruncFOp op : fp8TruncOps) {
+      rewriter.setInsertionPoint(op);
+      Location loc = op.getLoc();
+      rewriter.replaceOp(op,
+                         expandFpToFp8(loc, op.getOperand(), op.getType(),
+                                       f32ToFp8, i8Type, f32Type, rewriter));
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+triton::createExpandFloat8ConversionsPass() {
+  return std::make_unique<ExpandFloat8ConversionsPass>();
+}

--- a/python/examples/flaggems/fp8_matmul.py
+++ b/python/examples/flaggems/fp8_matmul.py
@@ -1,4 +1,5 @@
-"""FP8 Matrix Multiplication — Triton Kernel (Block-wise Scaling)
+"""FP8 Matrix Multiplication — Triton Kernel (Block-wise Scaling).
+
 Fixed config version for H20 deployment (no autotune warmup).
 
 API:
@@ -7,7 +8,7 @@ API:
     a:   (..., K)                    float8_e4m3fn, contiguous
     a_s: (..., K // group_size)      float32, per-token-group scale
     b:   (N, K)                      float8_e4m3fn, contiguous
-    b_s: (N // group_size, K // group_size)  float32, per-block scale
+    b_s: (ceil(N / group_size), ceil(K / group_size))  float32, per-block scale
     group_size = 128
 
     Returns: (..., N) bfloat16
@@ -74,8 +75,10 @@ def fp8_matmul_kernel(
     pid_m = first_pid_m + (pid % group_size_m)
     pid_n = (pid % num_pid_in_group) // group_size_m
 
-    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
-    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    offs_m_raw = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n_raw = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_m = offs_m_raw % M
+    offs_n = offs_n_raw % N
     offs_k = tl.arange(0, BLOCK_K)
 
     a_ptrs = A + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
@@ -115,7 +118,8 @@ def fp8_matmul_kernel(
 
     c = acc.to(tl.bfloat16)
     c_ptrs = C + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
-    tl.store(c_ptrs, c)
+    store_mask = (offs_m_raw[:, None] < M) & (offs_n_raw[None, :] < N)
+    tl.store(c_ptrs, c, mask=store_mask)
 
 
 def fp8_matmul(
@@ -131,7 +135,10 @@ def fp8_matmul(
         a:   (..., K)                        float8_e4m3fn, contiguous
         a_s: (..., K // 128)                 float32, per-token-group scale
         b:   (N, K)                          float8_e4m3fn, contiguous
-        b_s: (N // 128, K // 128)            float32, per-block scale
+        b_s: (ceil(N / 128), ceil(K / 128))  float32, per-block scale
+        scale_dtype: Scale storage dtype. float8_e8m0fnu scales are converted
+            to float32 before launch.
+
     Returns:
         (..., N) bfloat16
     """
@@ -143,6 +150,12 @@ def fp8_matmul(
     M = a.numel() // K
     N, K2 = b.shape
     assert K == K2
+    k_groups = triton.cdiv(K, GROUP_SIZE)
+    n_groups = triton.cdiv(N, GROUP_SIZE)
+    assert a_s.size(-1) >= k_groups
+    assert (
+        b_s.ndim == 2 and b_s.size(0) >= n_groups and b_s.size(1) >= k_groups
+    )
 
     if scale_dtype == torch.float8_e8m0fnu:
         a_s = a_s.to(torch.float32)

--- a/python/examples/flaggems/test_fp8_matmul.py
+++ b/python/examples/flaggems/test_fp8_matmul.py
@@ -13,6 +13,10 @@ def _make_fp8(x_f32):
     return x_f32.to(torch.float8_e4m3fn)
 
 
+def _ceil_div(a, b):
+    return (a + b - 1) // b
+
+
 @pytest.mark.parametrize("M, N, K", [(64, 64, 128), (128, 64, 256)])
 def test_fp8_matmul_forward(M, N, K):
     torch.manual_seed(0)
@@ -21,9 +25,30 @@ def test_fp8_matmul_forward(M, N, K):
     a = _make_fp8(a_f32)
     b = _make_fp8(b_f32)
     a_s = torch.ones(M, K // GROUP_SIZE, dtype=torch.float32)
-    b_s = torch.ones(N // GROUP_SIZE, K // GROUP_SIZE, dtype=torch.float32)
+    b_s = torch.ones(
+        _ceil_div(N, GROUP_SIZE), K // GROUP_SIZE, dtype=torch.float32
+    )
 
-    ref = torch.mm(a_f32, b_f32.t()).to(torch.bfloat16)
+    ref = torch.mm(a.float(), b.float().t()).to(torch.bfloat16)
+    tri_out = fp8_matmul(a, a_s, b, b_s)
+
+    torch.testing.assert_close(tri_out, ref, rtol=1e-1, atol=1e-1)
+
+
+def test_fp8_matmul_masks_tail_n_tile_with_ceil_scales():
+    torch.manual_seed(0)
+    M = 64
+    N = 193
+    K = 128
+    a_f32 = torch.randn(M, K, dtype=torch.float32)
+    b_f32 = torch.randn(N, K, dtype=torch.float32)
+    a = _make_fp8(a_f32)
+    b = _make_fp8(b_f32)
+    a_s = torch.ones(M, K // GROUP_SIZE, dtype=torch.float32)
+    b_s = torch.tensor([[1.0], [3.0]], dtype=torch.float32)
+
+    n_scale = b_s[torch.arange(N) // GROUP_SIZE, 0]
+    ref = (torch.mm(a.float(), b.float().t()) * n_scale).to(torch.bfloat16)
     tri_out = fp8_matmul(a, a_s, b, b_s)
 
     torch.testing.assert_close(tri_out, ref, rtol=1e-1, atol=1e-1)
@@ -40,9 +65,11 @@ def test_fp8_matmul_batched(shape):
     a = _make_fp8(a_f32)
     b = _make_fp8(b_f32)
     a_s = torch.ones(B, M, K // GROUP_SIZE, dtype=torch.float32)
-    b_s = torch.ones(N // GROUP_SIZE, K // GROUP_SIZE, dtype=torch.float32)
+    b_s = torch.ones(
+        _ceil_div(N, GROUP_SIZE), K // GROUP_SIZE, dtype=torch.float32
+    )
 
-    ref = torch.matmul(a_f32, b_f32.t()).to(torch.bfloat16)
+    ref = torch.matmul(a.float(), b.float().t()).to(torch.bfloat16)
     tri_out = fp8_matmul(a, a_s, b, b_s)
 
     torch.testing.assert_close(tri_out, ref, rtol=1e-1, atol=1e-1)

--- a/python/examples/flaggems/test_fp8_mqa_logits.py
+++ b/python/examples/flaggems/test_fp8_mqa_logits.py
@@ -23,13 +23,7 @@ def test_fp8_mqa_logits(M, H, D, N):
         clean_logits=False,
     )
 
-    # Reference: manual computation
-    score = torch.zeros(M, N, dtype=torch.float32)
-    for h in range(H):
-        q_h = q[:, h, :]
-        score_h = torch.mm(q_h, k.T)
-        score_h = torch.relu(score_h)
-        score += score_h * weights[:, h : h + 1]
-    ref = score
+    logits = torch.einsum("mhd,nd->mhn", q, k)
+    ref = torch.sum(torch.mul(torch.relu(logits), weights.unsqueeze(-1)), dim=1)
 
     torch.testing.assert_close(tri, ref, rtol=1e-3, atol=1e-3)

--- a/test/Transform/ExpandFloat8Conversions/vector.mlir
+++ b/test/Transform/ExpandFloat8Conversions/vector.mlir
@@ -1,0 +1,49 @@
+// RUN: triton-shared-opt --expand-float8-conversions %s | FileCheck %s
+
+module {
+  func.func @vector_fp8(%arg0: vector<4xf32>, %arg1: vector<4xf8E4M3FN>) -> (vector<4xf8E4M3FN>, vector<4xf32>) {
+    %0 = arith.truncf %arg0 : vector<4xf32> to vector<4xf8E4M3FN>
+    %1 = arith.extf %arg1 : vector<4xf8E4M3FN> to vector<4xf32>
+    return %0, %1 : vector<4xf8E4M3FN>, vector<4xf32>
+  }
+
+  func.func @vector_fp8_f16(%arg0: vector<4xf16>, %arg1: vector<4xf8E4M3FN>) -> (vector<4xf8E4M3FN>, vector<4xf16>) {
+    %0 = arith.truncf %arg0 : vector<4xf16> to vector<4xf8E4M3FN>
+    %1 = arith.extf %arg1 : vector<4xf8E4M3FN> to vector<4xf16>
+    return %0, %1 : vector<4xf8E4M3FN>, vector<4xf16>
+  }
+
+  func.func @keeps_loaded_llvm_dialect(%arg0: vector<4xi1>, %arg1: vector<4xi32>, %arg2: vector<4xi32>) -> vector<4xi32> {
+    %0 = llvm.select %arg0, %arg1, %arg2 : vector<4xi1>, vector<4xi32>
+    return %0 : vector<4xi32>
+  }
+}
+
+// CHECK-DAG: func.func private @__triton_shared_f32_to_fp8e4nv(f32) -> i8
+// CHECK-DAG: func.func private @__triton_shared_fp8e4nv_to_f32(i8) -> f32
+// CHECK:     func.func @vector_fp8
+// CHECK-NOT: arith.truncf {{.*}} to vector<4xf8E4M3FN>
+// CHECK-NOT: arith.extf {{.*}} : vector<4xf8E4M3FN>
+// CHECK:       scf.for
+// CHECK:         vector.extractelement
+// CHECK:         call @__triton_shared_f32_to_fp8e4nv
+// CHECK:         vector.insertelement
+// CHECK:       scf.for
+// CHECK:         vector.extractelement
+// CHECK:         call @__triton_shared_fp8e4nv_to_f32
+// CHECK:         vector.insertelement
+// CHECK:       return
+// CHECK:     func.func @vector_fp8_f16
+// CHECK:       scf.for
+// CHECK:         vector.extractelement
+// CHECK:         arith.extf {{.*}} : f16 to f32
+// CHECK:         call @__triton_shared_f32_to_fp8e4nv
+// CHECK:         vector.insertelement
+// CHECK:       scf.for
+// CHECK:         vector.extractelement
+// CHECK:         call @__triton_shared_fp8e4nv_to_f32
+// CHECK:         arith.truncf {{.*}} : f32 to f16
+// CHECK:         vector.insertelement
+// CHECK:       return
+// CHECK:     func.func @keeps_loaded_llvm_dialect
+// CHECK:       llvm.select

--- a/tools/triton-shared-opt/RegisterTritonSharedDialects.h
+++ b/tools/triton-shared-opt/RegisterTritonSharedDialects.h
@@ -6,6 +6,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Ptr/IR/PtrDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
@@ -22,6 +23,7 @@
 #include "triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h"
 #include "triton-shared/Dialect/TritonTilingExt/IR/TritonTilingExtDialect.h"
 #include "triton-shared/Transform/AddLLVMDebugInfo/Passes.h"
+#include "triton-shared/Transform/ExpandFloat8Conversions/Passes.h"
 
 #include "mlir/InitAllPasses.h"
 
@@ -38,6 +40,7 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerTritonArithToLinalgPasses();
   mlir::triton::registerStructuredToMemrefPasses();
   mlir::triton::registerAddLLVMDebugInfoPass();
+  mlir::triton::registerExpandFloat8ConversionsPass();
 
   // TODO: register Triton & TritonGPU passes
   registry.insert<
@@ -47,5 +50,6 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
       mlir::math::MathDialect, mlir::arith::ArithDialect, mlir::scf::SCFDialect,
       mlir::linalg::LinalgDialect, mlir::func::FuncDialect,
       mlir::tensor::TensorDialect, mlir::memref::MemRefDialect,
-      mlir::bufferization::BufferizationDialect>();
+      mlir::bufferization::BufferizationDialect,
+      mlir::vector::VectorDialect>();
 }


### PR DESCRIPTION
# Summary  
This PR introduces support for FP8 (specifically Float8E4M3FN) conversions in the Triton-RISCV backend.

## Key Changes
  - ExpandFloat8Conversions Pass: Added a new MLIR transformation pass to expand FP8 ↔ F32 conversions into calls to
    helper functions (**triton_shared_fp8e4nv_to_f32 and **triton_shared_f32_to_fp8e4nv).
  - Backend Integration: Updated backend/compiler.py to automatically trigger the expansion pass when FP8 types are
    detected in the IR.
  - Testing:
    - Added FP8 matmul and MQA logits tests in python/examples/flaggems/.
    - Added MLIR-level regression tests in test/Transform/ExpandFloat8Conversions/vector.mlir.
    - Registered the new pass in triton-shared-opt.