### PR TITLE
Enhance TritonStructured dialect and improve lowering robustness

### DIFF
--- a/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
+++ b/include/triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.td
@@ -2,6 +2,7 @@
 #define TRITON_STRUCTURED_DIALECT
 
 include "mlir/IR/OpBase.td"
+include "triton/Dialect/Triton/IR/TritonAttrDefs.td"
 include "triton/Dialect/Triton/IR/TritonTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -233,8 +234,8 @@ def TTS_GetStructuredStateOp : TTS_Op<"get_structured_state", [AttrSizedResultSe
   let summary = "Placeholder for the structured pointer states computed during PtrAnalysis.";
   let description = "Used to pass the offsets and strides to scf.for op to simplify IR rewrites.";
 
-  let arguments = (ins AnyTypeOf<[TT_PtrLike, I32Tensor]>:$input);
-  let results = (outs AnyTypeOf<[TT_PtrLike, I32Tensor]>:$structured, Variadic<Index>:$offsets, Variadic<Index>:$strides);
+  let arguments = (ins AnyTypeOf<[TT_PtrLike, TT_IntTensor]>:$input);
+  let results = (outs AnyTypeOf<[TT_PtrLike, TT_IntTensor]>:$structured, Variadic<Index>:$offsets, Variadic<Index>:$strides);
 
   let builders = [
     OpBuilder<(ins "Value":$input)>,
@@ -294,6 +295,57 @@ def TTS_ScatterOp : TTS_Op<"scatter", [
   let assemblyFormat = [{
     $value `into` $ptr `[` $offset `]` (`mask` `=` $mask^)?
     attr-dict `:` type($value) `into` ` ` `(` type($ptr) `,` type($offset) `)`
+  }];
+}
+
+def TTS_AtomicRMWOp : TTS_Op<"atomic_rmw", [
+  MemoryEffects<[MemRead, MemWrite]>,
+  OptionalTypesMatchWith<"mask type matches offset type", "offset", "mask",
+                 "triton::getI1SameShape($_self)">
+]> {
+  let summary = "atomically update data through an unstructured pointer";
+
+  let arguments = (
+    ins
+    TT_AtomicRMWAttr:$atomic_rmw_op,
+    TT_Ptr:$ptr,
+    TT_IntLike:$offset,
+    TT_Type:$val,
+    Optional<TT_BoolLike>:$mask,
+    TT_MemSemanticAttr:$sem,
+    TT_MemSyncScopeAttr:$scope
+  );
+
+  let results = (outs TT_Type:$result);
+
+  let assemblyFormat = [{
+    $atomic_rmw_op `,` $sem `,` $scope `,` $val `into` $ptr `[` $offset `]`
+    (`mask` `=` $mask^)? attr-dict `:` type($val) `into` ` `
+    `(` type($ptr) `,` type($offset) `)` `->` type($result)
+  }];
+}
+
+def TTS_AtomicCASOp : TTS_Op<"atomic_cas", [
+  MemoryEffects<[MemRead, MemWrite]>
+]> {
+  let summary = "compare-and-swap through an unstructured pointer";
+
+  let arguments = (
+    ins
+    TT_Ptr:$ptr,
+    TT_IntLike:$offset,
+    TT_Type:$cmp,
+    TT_Type:$val,
+    TT_MemSemanticAttr:$sem,
+    TT_MemSyncScopeAttr:$scope
+  );
+
+  let results = (outs TT_Type:$result);
+
+  let assemblyFormat = [{
+    $sem `,` $scope `,` $cmp `,` $val `into` $ptr `[` $offset `]`
+    attr-dict `:` type($cmp) `,` type($val) `into` ` `
+    `(` type($ptr) `,` type($offset) `)` `->` type($result)
   }];
 }
 

--- a/lib/Analysis/MaskAnalysis.cpp
+++ b/lib/Analysis/MaskAnalysis.cpp
@@ -399,6 +399,11 @@ LogicalResult MaskState::parseAnd(arith::AndIOp andOp, const Location loc,
                                                      OpBuilder &builder,
                                                      Location loc) {
             OpFoldResult ofr = state.isMask() ? state.dims[dim] : state.scalar;
+            if (!ofr) {
+              // No structured bound for this dimension means the structured
+              // side does not restrict the unstructured mask.
+              return Value();
+            }
             if (auto intV = getIntAttr(ofr)) {
               if (intV == size) {
                 // Full mask.

--- a/lib/Analysis/OpFoldResultUtils.cpp
+++ b/lib/Analysis/OpFoldResultUtils.cpp
@@ -20,6 +20,9 @@
 namespace mlir {
 
 std::optional<int64_t> getIntAttr(const OpFoldResult ofr) {
+  if (!ofr)
+    return std::nullopt;
+
   if (isa<Attribute>(ofr) && isa<IntegerAttr>(cast<Attribute>(ofr)))
     return dyn_cast<IntegerAttr>(cast<Attribute>(ofr)).getInt();
 

--- a/lib/AnalysisStructured/PtrAnalysis.cpp
+++ b/lib/AnalysisStructured/PtrAnalysis.cpp
@@ -39,6 +39,14 @@
 
 using namespace mlir;
 
+static void ensureMaskDimsCoverRank(triton::MaskState &mstate,
+                                    ArrayRef<int64_t> sizes,
+                                    OpBuilder &builder) {
+  while (mstate.dims.size() < sizes.size()) {
+    mstate.dims.push_back(builder.getIndexAttr(sizes[mstate.dims.size()]));
+  }
+}
+
 // Try to apply unstructured mask on the ptr.
 static Value applyUnstructuredMask(Operation *op, Value ptr,
                                    triton::MaskState &mstate, Location loc,
@@ -72,6 +80,7 @@ static Value applyUnstructuredMask(Operation *op, Value ptr,
                 gatherScatterPtr.getSizes(), gatherScatterPtr.getMixedStrides(),
                 gatherScatterPtr.getMixedOffsets())
             .getResult();
+    ensureMaskDimsCoverRank(mstate, gatherScatterPtr.getSizes(), builder);
   } else if (auto structuredPtr = ptr.getDefiningOp<tts::MakeTensorPtrOp>()) {
     auto ofrToI32Value = [&](OpFoldResult ofr) {
       Value v = dyn_cast<Value>(ofr);
@@ -117,6 +126,7 @@ static Value applyUnstructuredMask(Operation *op, Value ptr,
                   structuredPtr.getMixedStrides(),
                   structuredPtr.getMixedOffsets())
               .getResult();
+    ensureMaskDimsCoverRank(mstate, structuredPtr.getSizes(), builder);
   } else {
     return nullptr;
   }
@@ -1958,9 +1968,8 @@ LogicalResult PtrAnalysis::rewriteOp(Operation *rootOp, bool useUnsafeMask) {
               if (!knownPtrs.contains(tritonValue)) {
                 PtrState state;
                 OpBuilder b(getStateOp);
-                if (succeeded(
-                        visitOperand(tritonValue, state, getStateOp->getLoc(),
-                                     b))) {
+                if (succeeded(visitOperand(tritonValue, state,
+                                           getStateOp->getLoc(), b))) {
                   knownPtrs[tritonValue] = state;
                 } else {
                   LLVM_DEBUG(getStateOp->emitRemark(

--- a/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -52,6 +52,7 @@ using namespace mlir;
 
 static const std::string WRAP_SIDE_BY_SIDE = "wrap_side_by_side";
 static const std::string WRAP_STACKED = "wrap_stacked";
+static const std::string WRAP_LINEAR = "wrap_linear";
 
 static bool hasUnitStride1DLayout(MemRefType memrefType) {
   if (memrefType.getRank() != 1) {
@@ -346,6 +347,21 @@ static OpFoldResult accumulateTargetOffset(Location loc,
   return targetOffset;
 }
 
+static SmallVector<Value, 2> computeRank1SplitSizes(Location loc, Value start,
+                                                    Value size, Value modulo,
+                                                    Value stride,
+                                                    OpBuilder &b) {
+  // start and modulo are linear offsets; reinterpret_cast sizes are elements.
+  Value remaining = b.create<arith::SubIOp>(loc, modulo, start);
+  Value one = b.create<arith::ConstantIndexOp>(loc, 1);
+  Value strideMinusOne = b.create<arith::SubIOp>(loc, stride, one);
+  Value numerator = b.create<arith::AddIOp>(loc, remaining, strideMinusOne);
+  Value elementsUntilWrap = b.create<arith::DivSIOp>(loc, numerator, stride);
+  Value d1 = b.create<arith::MinSIOp>(loc, size, elementsUntilWrap);
+  Value d2 = b.create<arith::SubIOp>(loc, size, d1);
+  return {d1, d2};
+}
+
 static FailureOr<Value> materializeStructuredTPtrMemRef(tts::MakeTensorPtrOp op,
                                                         Location loc,
                                                         OpBuilder &rewriter) {
@@ -403,17 +419,9 @@ static FailureOr<Value> materializeSplitTPtrMemRef(tts::MakeTensorPtrOp op,
   }
 
   auto resultShape = cast<RankedTensorType>(op.getType()).getShape();
-  if (resultShape.size() != 2) {
-    return failure();
-  }
-
-  auto resultType = getResultMemrefType(
-      op, /*offset=*/ShapedType::kDynamic,
-      SmallVector<int64_t>(resultShape.size(), ShapedType::kDynamic),
-      SmallVector<int64_t>{ShapedType::kDynamic, ShapedType::kDynamic});
-  auto targetOffset =
-      ofrToIndexValue(accumulateTargetOffset(loc, op.getMixedOffsets(), rewriter),
-                      loc, rewriter);
+  auto targetOffset = ofrToIndexValue(
+      accumulateTargetOffset(loc, op.getMixedOffsets(), rewriter), loc,
+      rewriter);
   auto parentShape = op.getStaticShape();
 
   auto isSplitDimension = [](int64_t dim) {
@@ -422,6 +430,55 @@ static FailureOr<Value> materializeSplitTPtrMemRef(tts::MakeTensorPtrOp op,
 
   SmallVector<Value> strideVals =
       ofrsToIndexValues(getMixedStridesForMemref(op, rewriter), loc, rewriter);
+
+  if (resultShape.size() == 1) {
+    if (parentShape.size() != 1) {
+      return failure();
+    }
+    if (!isSplitDimension(parentShape[0])) {
+      return materializeStructuredTPtrMemRef(op, loc, rewriter);
+    }
+
+    auto resultType = getResultMemrefType(
+        op, /*offset=*/ShapedType::kDynamic,
+        SmallVector<int64_t>(resultShape.size(), ShapedType::kDynamic),
+        SmallVector<int64_t>{ShapedType::kDynamic});
+    Value size = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(op.getSizes()[0]));
+    Value modulo = ofrToIndexValue(op.getMixedShape()[0], loc, rewriter);
+    Value start = rewriter.create<arith::RemSIOp>(loc, targetOffset, modulo);
+    auto splitSizes = computeRank1SplitSizes(loc, start, size, modulo,
+                                             strideVals[0], rewriter);
+    Value d1 = splitSizes[0];
+    Value d2 = splitSizes[1];
+    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+    SmallVector<Value> casts;
+    casts.push_back(rewriter
+                        .create<memref::ReinterpretCastOp>(
+                            loc, resultType, base, start, ValueRange{d1},
+                            ValueRange{strideVals[0]})
+                        .getResult());
+    casts.push_back(rewriter
+                        .create<memref::ReinterpretCastOp>(
+                            loc, resultType, base, zero, ValueRange{d2},
+                            ValueRange{strideVals[0]})
+                        .getResult());
+
+    auto combinedCast =
+        rewriter.create<UnrealizedConversionCastOp>(loc, op.getType(), casts);
+    combinedCast->setAttr(WRAP_LINEAR, rewriter.getUnitAttr());
+    return combinedCast.getResult(0);
+  }
+
+  if (resultShape.size() != 2 || parentShape.size() != 2) {
+    return failure();
+  }
+
+  auto resultType = getResultMemrefType(
+      op, /*offset=*/ShapedType::kDynamic,
+      SmallVector<int64_t>(resultShape.size(), ShapedType::kDynamic),
+      SmallVector<int64_t>{ShapedType::kDynamic, ShapedType::kDynamic});
   Value rowSize = rewriter.create<arith::ConstantOp>(
       loc, rewriter.getIndexAttr(op.getSizes()[0]));
   Value colSize = rewriter.create<arith::ConstantOp>(
@@ -492,7 +549,8 @@ static UnrealizedConversionCastOp getWraparoundCast(Value ptr) {
   if (!castOp) {
     return nullptr;
   }
-  if (!castOp->hasAttr(WRAP_SIDE_BY_SIDE) && !castOp->hasAttr(WRAP_STACKED)) {
+  if (!castOp->hasAttr(WRAP_SIDE_BY_SIDE) && !castOp->hasAttr(WRAP_STACKED) &&
+      !castOp->hasAttr(WRAP_LINEAR)) {
     return nullptr;
   }
   return castOp;
@@ -1099,8 +1157,6 @@ private:
   LogicalResult rewriteSplitPtr(tts::MakeTensorPtrOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
     auto parentShape = op.getStaticShape();
-    assert(parentShape.size() == 2 &&
-           "Only support split pointer for 2D tensors only");
     SmallVector<Value> casts;
     StringRef wrapType;
 
@@ -1110,7 +1166,43 @@ private:
       return dim == ShapedType::kDynamic || dim != 0;
     };
 
-    if (isSplitDimension(parentShape[0])) {
+    if (parentShape.size() == 1) {
+      if (!isSplitDimension(parentShape[0])) {
+        return rewriteStructuredPtr(op, adaptor, rewriter);
+      }
+
+      auto loc = op->getLoc();
+      auto resultShape = cast<RankedTensorType>(op.getType()).getShape();
+      auto resultType = getResultMemrefType(
+          op, /*offset=*/ShapedType::kDynamic,
+          SmallVector<int64_t>(resultShape.size(), ShapedType::kDynamic),
+          SmallVector<int64_t>{ShapedType::kDynamic});
+      Value targetOffset = ofrToIndexValue(
+          accumulateTargetOffset(op.getLoc(), op.getMixedOffsets(), rewriter),
+          loc, rewriter);
+      Value size = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIndexAttr(op.getSizes()[0]));
+      Value stride = ofrToIndexValue(op.getMixedStrides()[0], loc, rewriter);
+      Value modulo = ofrToIndexValue(op.getMixedShape()[0], loc, rewriter);
+      Value start = rewriter.create<arith::RemSIOp>(loc, targetOffset, modulo);
+      auto splitSizes =
+          computeRank1SplitSizes(loc, start, size, modulo, stride, rewriter);
+      Value d1 = splitSizes[0];
+      Value d2 = splitSizes[1];
+      Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+      auto cast1 = rewriter.create<memref::ReinterpretCastOp>(
+          loc, resultType, adaptor.getBase(), start, ValueRange{d1},
+          ValueRange{stride});
+      auto cast2 = rewriter.create<memref::ReinterpretCastOp>(
+          loc, resultType, adaptor.getBase(), zero, ValueRange{d2},
+          ValueRange{stride});
+      casts = {cast1.getResult(), cast2.getResult()};
+      wrapType = WRAP_LINEAR;
+    } else if (parentShape.size() != 2) {
+      return rewriter.notifyMatchFailure(
+          op, "split pointer lowering supports only rank-1 and rank-2 shapes");
+    } else if (isSplitDimension(parentShape[0])) {
       // Stacked case
       assert(parentShape[1] == 0);
       auto [cast1, cast2] = createStackedCastOps(op, adaptor, rewriter);
@@ -1240,6 +1332,7 @@ private:
     if (ptrDefiningOp &&
         (ptrDefiningOp->hasAttr(WRAP_SIDE_BY_SIDE) ||
          ptrDefiningOp->hasAttr(WRAP_STACKED) ||
+         ptrDefiningOp->hasAttr(WRAP_LINEAR) ||
          isa<tts::MakeGatherScatterTensorPtrOp>(ptrDefiningOp))) {
       return false;
     }
@@ -1458,6 +1551,23 @@ private:
     rewriter.create<memref::CopyOp>(loc, block2, block2Dst);
   }
 
+  void createLinearCopies(Value block1, Value block2, Value dst, Location loc,
+                          ConversionPatternRewriter &rewriter) const {
+    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value block1Size = rewriter.create<memref::DimOp>(loc, block1, 0);
+    Value block2Size = rewriter.create<memref::DimOp>(loc, block2, 0);
+
+    auto block1Dst = rewriter.create<memref::SubViewOp>(
+        loc, dst, ValueRange{zero}, ValueRange{block1Size}, ValueRange{one});
+    auto block2Dst = rewriter.create<memref::SubViewOp>(
+        loc, dst, ValueRange{block1Size}, ValueRange{block2Size},
+        ValueRange{one});
+
+    rewriter.create<memref::CopyOp>(loc, block1, block1Dst);
+    rewriter.create<memref::CopyOp>(loc, block2, block2Dst);
+  }
+
   memref::SubViewOp createSubview(Value src, ArrayRef<OpFoldResult> offsets,
                                   ArrayRef<OpFoldResult> sizes,
                                   ArrayRef<OpFoldResult> strides, Location loc,
@@ -1510,6 +1620,29 @@ private:
     return {sv1, sv2};
   }
 
+  std::pair<memref::SubViewOp, memref::SubViewOp>
+  getLinearSubviews(ArrayRef<OpFoldResult> dims, Value block1, Value block2,
+                    Location loc, ConversionPatternRewriter &rewriter) const {
+    Value requested = ofrToIndexValue(dims[0], loc, rewriter);
+    Value block1Size = rewriter.create<memref::DimOp>(loc, block1, 0);
+    Value block2Size = rewriter.create<memref::DimOp>(loc, block2, 0);
+    Value size1 = rewriter.create<arith::MinSIOp>(loc, requested, block1Size);
+    Value remaining = rewriter.create<arith::SubIOp>(loc, requested, size1);
+    Value size2 = rewriter.create<arith::MinSIOp>(loc, remaining, block2Size);
+    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+    SmallVector<OpFoldResult> zeroOffset{zero};
+    SmallVector<OpFoldResult> size1Ofr{size1};
+    SmallVector<OpFoldResult> size2Ofr{size2};
+    SmallVector<OpFoldResult> oneStride{one};
+    auto sv1 =
+        createSubview(block1, zeroOffset, size1Ofr, oneStride, loc, rewriter);
+    auto sv2 =
+        createSubview(block2, zeroOffset, size2Ofr, oneStride, loc, rewriter);
+    return {sv1, sv2};
+  }
+
   std::pair<tensor::ExtractSliceOp, tensor::ExtractSliceOp>
   getSideBySideSlices(Value source, Value block1, Value block2, Location loc,
                       ConversionPatternRewriter &rewriter) const {
@@ -1546,8 +1679,24 @@ private:
     return {slice1, slice2};
   }
 
-  LogicalResult rewriteStructuredLoad(tts::LoadOp op, Value ptr,
-                                      ConversionPatternRewriter &rewriter) const {
+  std::pair<tensor::ExtractSliceOp, tensor::ExtractSliceOp>
+  getLinearSlices(Value source, Value block1, Value block2, Location loc,
+                  ConversionPatternRewriter &rewriter) const {
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value size1 = rewriter.create<memref::DimOp>(loc, block1, 0);
+    Value size2 = rewriter.create<memref::DimOp>(loc, block2, 0);
+
+    auto slice1 = rewriter.create<tensor::ExtractSliceOp>(
+        loc, source, ValueRange{c0}, ValueRange{size1}, ValueRange{c1});
+    auto slice2 = rewriter.create<tensor::ExtractSliceOp>(
+        loc, source, ValueRange{size1}, ValueRange{size2}, ValueRange{c1});
+    return {slice1, slice2};
+  }
+
+  LogicalResult
+  rewriteStructuredLoad(tts::LoadOp op, Value ptr,
+                        ConversionPatternRewriter &rewriter) const {
     assert(!op.hasMask());
 
     auto loc = op->getLoc();
@@ -1568,6 +1717,8 @@ private:
         createSideBySideCopies(block1, block2, alloc, loc, rewriter);
       } else if (unrealizedCast->hasAttr(WRAP_STACKED)) {
         createStackedCopies(block1, block2, alloc, loc, rewriter);
+      } else if (unrealizedCast->hasAttr(WRAP_LINEAR)) {
+        createLinearCopies(block1, block2, alloc, loc, rewriter);
       } else {
         llvm_unreachable("unexpected wraparound type");
       }
@@ -1682,6 +1833,33 @@ private:
         init = rewriter.create<tensor::InsertSliceOp>(
             loc, tensor2, init, ValueRange{rowSize1, c0},
             ValueRange{rowSize2, colSize}, ValueRange{c1, c1});
+      } else if (unrealizedCast->hasAttr(WRAP_LINEAR)) {
+        auto [subview1, subview2] =
+            getLinearSubviews(mixedDims, block1, block2, loc, rewriter);
+        auto subview1Type = cast<MemRefType>(subview1.getType());
+        auto subview2Type = cast<MemRefType>(subview2.getType());
+        auto slice1Type =
+            RankedTensorType::get(subview1Type.getShape(), elemType);
+        auto slice2Type =
+            RankedTensorType::get(subview2Type.getShape(), elemType);
+        auto genericSliceType = RankedTensorType::get(
+            SmallVector<int64_t>{ShapedType::kDynamic}, elemType);
+        Value tensor1 =
+            createTensorFromMemref(op, subview1, slice1Type, rewriter);
+        Value tensor2 =
+            createTensorFromMemref(op, subview2, slice2Type, rewriter);
+        tensor1 =
+            rewriter.create<tensor::CastOp>(loc, genericSliceType, tensor1);
+        tensor2 =
+            rewriter.create<tensor::CastOp>(loc, genericSliceType, tensor2);
+        Value size1 = rewriter.create<memref::DimOp>(loc, subview1, 0);
+        Value size2 = rewriter.create<memref::DimOp>(loc, subview2, 0);
+        init = rewriter.create<tensor::InsertSliceOp>(
+            loc, tensor1, init, ValueRange{c0}, ValueRange{size1},
+            ValueRange{c1});
+        init = rewriter.create<tensor::InsertSliceOp>(
+            loc, tensor2, init, ValueRange{size1}, ValueRange{size2},
+            ValueRange{c1});
       } else {
         llvm_unreachable("unexpected wraparound type");
       }
@@ -1747,19 +1925,7 @@ private:
     SmallVector<Value> dynSizes; // sizes are always static
     auto sizes = mlir::getMixedValues(staticSizes, dynSizes, rewriter);
 
-    // Create alloc to save the result.
     auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
-    auto allocType =
-        MemRefType::get(resultType.getShape(), resultType.getElementType());
-    auto alloc = rewriter.create<memref::AllocOp>(loc, allocType);
-
-    auto allocStrides = mlir::getMixedValues(
-        allocType.getStridesAndOffset().first, dynSizes, rewriter);
-    // Fill load destination with other value
-    if (Value other = op.getOther()) {
-      fillWithValue(loc, alloc, other, resultType.getShape(),
-                    op.getMixedMaskDims(), op.getStaticMaskDims(), rewriter);
-    }
 
     // Create loop to iterate every offset in gatherOffset.
     auto lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
@@ -1796,6 +1962,81 @@ private:
       }
     }
     auto step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+    if (resultType.getRank() == 1) {
+      SmallVector<Value> dynamicDims;
+      if (resultType.isDynamicDim(0)) {
+        dynamicDims.push_back(
+            rewriter.create<tensor::DimOp>(loc, gatherOffset, 0));
+      }
+      Value result = rewriter.create<tensor::EmptyOp>(
+          loc, resultType.getShape(), resultType.getElementType(), dynamicDims);
+      if (Value other = op.getOther()) {
+        result = rewriter
+                     .create<linalg::FillOp>(loc, ValueRange{other},
+                                             ValueRange{result})
+                     .getResult(0);
+      }
+
+      auto loop = rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step,
+                                              ValueRange{result});
+      rewriter.setInsertionPointToStart(loop.getBody());
+      Value inductionVar = loop.getInductionVar();
+      Value tensorAcc = loop.getRegionIterArgs()[0];
+      Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+      auto buildInsert = [&](OpBuilder &builder, Value acc) -> Value {
+        auto gatherOffsetElt = builder.create<tensor::ExtractOp>(
+            loc, gatherOffset, ValueRange{inductionVar});
+        Value srcPtr = rewriteGatherScatterPtrElement(
+            staticSizes, ptr, memRefPtr, gatherOffsetElt.getResult(), gatherDim,
+            rewriter);
+        Value loaded =
+            builder.create<memref::LoadOp>(loc, srcPtr, ValueRange{zero});
+        return builder
+            .create<tensor::InsertOp>(loc, loaded, acc,
+                                      ValueRange{inductionVar})
+            .getResult();
+      };
+
+      Value nextTensor;
+      if (Value unstructuredMask = ptr.getGatherScatterMask()) {
+        auto maskValue = rewriter.create<tensor::ExtractOp>(
+            loc, unstructuredMask, ValueRange{inductionVar});
+        auto ifOp =
+            rewriter.create<scf::IfOp>(loc, tensorAcc.getType(), maskValue,
+                                       /*withElseRegion=*/true);
+        {
+          OpBuilder::InsertionGuard guard(rewriter);
+          rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+          rewriter.create<scf::YieldOp>(loc, buildInsert(rewriter, tensorAcc));
+        }
+        {
+          OpBuilder::InsertionGuard guard(rewriter);
+          rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
+          rewriter.create<scf::YieldOp>(loc, tensorAcc);
+        }
+        nextTensor = ifOp.getResult(0);
+      } else {
+        nextTensor = buildInsert(rewriter, tensorAcc);
+      }
+      rewriter.create<scf::YieldOp>(loc, nextTensor);
+      rewriter.replaceOp(op, loop.getResult(0));
+
+      return success();
+    }
+
+    // Create alloc to save the result.
+    auto allocType =
+        MemRefType::get(resultType.getShape(), resultType.getElementType());
+    auto alloc = rewriter.create<memref::AllocOp>(loc, allocType);
+
+    // Fill load destination with other value.
+    if (Value other = op.getOther()) {
+      fillWithValue(loc, alloc, other, resultType.getShape(),
+                    op.getMixedMaskDims(), op.getStaticMaskDims(), rewriter);
+    }
+
     auto loop = rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
 
     // Create tensor from alloc and use it as the result to replace op.
@@ -1925,6 +2166,7 @@ private:
     if (ptrDefiningOp &&
         (ptrDefiningOp->hasAttr(WRAP_SIDE_BY_SIDE) ||
          ptrDefiningOp->hasAttr(WRAP_STACKED) ||
+         ptrDefiningOp->hasAttr(WRAP_LINEAR) ||
          isa<tts::MakeGatherScatterTensorPtrOp>(ptrDefiningOp))) {
       return false;
     }
@@ -2037,6 +2279,41 @@ private:
         loc, source, ValueRange{rowSize1, c0}, ValueRange{rowSize2, colSize},
         ValueRange{c1, c1});
     return {slice1, slice2};
+  }
+
+  std::pair<tensor::ExtractSliceOp, tensor::ExtractSliceOp>
+  getLinearSlices(Value source, Value block1, Value block2, Location loc,
+                  ConversionPatternRewriter &rewriter) const {
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value size1 = rewriter.create<memref::DimOp>(loc, block1, 0);
+    Value size2 = rewriter.create<memref::DimOp>(loc, block2, 0);
+
+    auto slice1 = rewriter.create<tensor::ExtractSliceOp>(
+        loc, source, ValueRange{c0}, ValueRange{size1}, ValueRange{c1});
+    auto slice2 = rewriter.create<tensor::ExtractSliceOp>(
+        loc, source, ValueRange{size1}, ValueRange{size2}, ValueRange{c1});
+    return {slice1, slice2};
+  }
+
+  std::pair<memref::SubViewOp, memref::SubViewOp>
+  getLinearMaskedStoreSubviews(tts::StoreOp op, Value block1, Value block2,
+                               Location loc,
+                               ConversionPatternRewriter &rewriter) const {
+    Value requested = ofrToIndexValue(op.getMixedMaskDims()[0], loc, rewriter);
+    Value block1Size = rewriter.create<memref::DimOp>(loc, block1, 0);
+    Value block2Size = rewriter.create<memref::DimOp>(loc, block2, 0);
+    Value size1 = rewriter.create<arith::MinSIOp>(loc, requested, block1Size);
+    Value remaining = rewriter.create<arith::SubIOp>(loc, requested, size1);
+    Value size2 = rewriter.create<arith::MinSIOp>(loc, remaining, block2Size);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+    auto block1Subview = rewriter.create<memref::SubViewOp>(
+        loc, block1, ValueRange{c0}, ValueRange{size1}, ValueRange{c1});
+    auto block2Subview = rewriter.create<memref::SubViewOp>(
+        loc, block2, ValueRange{c0}, ValueRange{size2}, ValueRange{c1});
+    return {block1Subview, block2Subview};
   }
 
   LogicalResult rewriteScatter(tts::MakeGatherScatterTensorPtrOp ptr,
@@ -2218,7 +2495,7 @@ public:
       auto block1 = memrefs[0];
       auto block2 = memrefs[1];
 
-      if (op.hasMask()) {
+      if (op.hasMask() && !unrealizedCast->hasAttr(WRAP_LINEAR)) {
         return rewriter.notifyMatchFailure(
             op, "masked split-pointer store is not implemented");
       }
@@ -2241,6 +2518,32 @@ public:
         auto store2 = rewriter.create<bufferization::MaterializeInDestinationOp>(
             loc, slice2, block2);
         store2.setWritable(true);
+      } else if (unrealizedCast->hasAttr(WRAP_LINEAR)) {
+        if (op.hasMask()) {
+          auto [block1Subview, block2Subview] =
+              getLinearMaskedStoreSubviews(op, block1, block2, loc, rewriter);
+          auto [slice1, slice2] = getLinearSlices(
+              adaptor.getValue(), block1Subview, block2Subview, loc, rewriter);
+          auto store1 =
+              rewriter.create<bufferization::MaterializeInDestinationOp>(
+                  loc, slice1, block1Subview);
+          store1.setWritable(true);
+          auto store2 =
+              rewriter.create<bufferization::MaterializeInDestinationOp>(
+                  loc, slice2, block2Subview);
+          store2.setWritable(true);
+        } else {
+          auto [slice1, slice2] = getLinearSlices(adaptor.getValue(), block1,
+                                                  block2, loc, rewriter);
+          auto store1 =
+              rewriter.create<bufferization::MaterializeInDestinationOp>(
+                  loc, slice1, block1);
+          store1.setWritable(true);
+          auto store2 =
+              rewriter.create<bufferization::MaterializeInDestinationOp>(
+                  loc, slice2, block2);
+          store2.setWritable(true);
+        }
       } else {
         llvm_unreachable("unexpected wraparound type");
       }

--- a/lib/Conversion/TritonToUnstructured/TritonToUnstructuredPass.cpp
+++ b/lib/Conversion/TritonToUnstructured/TritonToUnstructuredPass.cpp
@@ -216,6 +216,43 @@ static unsigned int getBitWidth(Type type) {
   return 0;
 }
 
+static bool isPointerPreservingDerivedOp(Operation *op) {
+  return isa<triton::AddPtrOp, triton::SplatOp, triton::BroadcastOp,
+             triton::ExpandDimsOp, triton::BitcastOp>(op);
+}
+
+static bool reachesScfIfYieldThroughDerivedPtrs(Value value) {
+  llvm::SmallDenseSet<Value> visited;
+  SmallVector<Value> workList{value};
+
+  while (!workList.empty()) {
+    Value curr = workList.pop_back_val();
+    if (!visited.insert(curr).second) {
+      continue;
+    }
+
+    for (Operation *user : curr.getUsers()) {
+      if (auto yield = dyn_cast<scf::YieldOp>(user)) {
+        if (isa<scf::IfOp>(yield->getParentOp())) {
+          return true;
+        }
+        continue;
+      }
+
+      if (!isPointerPreservingDerivedOp(user) || user->getNumResults() != 1) {
+        continue;
+      }
+
+      Value result = user->getResult(0);
+      if (triton::isPtrTypeLike(result.getType())) {
+        workList.push_back(result);
+      }
+    }
+  }
+
+  return false;
+}
+
 class TritonToUnstructuredPass
     : public TritonToUnstructuredBase<TritonToUnstructuredPass> {
 
@@ -239,6 +276,78 @@ public:
     // the offset value
     Value offset;
   };
+
+  struct OperandReplacement {
+    Operation *op;
+    unsigned operandIndex;
+    Value replacement;
+  };
+
+  static Type getScalarPtrType(Type ptrLikeType) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(ptrLikeType)) {
+      return tensorType.getElementType();
+    }
+    return ptrLikeType;
+  }
+
+  static Value materializeBasePtr(PtrOffset offsetInfo, Location loc,
+                                  OpBuilder &builder) {
+    Type scalarPtrType = getScalarPtrType(offsetInfo.ptrType);
+    if (offsetInfo.ptr.getType() == scalarPtrType) {
+      return offsetInfo.ptr;
+    }
+    return builder.create<triton::BitcastOp>(loc, scalarPtrType,
+                                             offsetInfo.ptr);
+  }
+
+  static Value castScalarOffset(Value offset, Type targetType, Location loc,
+                                OpBuilder &builder) {
+    if (offset.getType() == targetType) {
+      return offset;
+    }
+
+    if (targetType.isIndex()) {
+      return builder.create<arith::IndexCastOp>(loc, targetType, offset);
+    }
+
+    if (offset.getType().isIndex()) {
+      return builder.create<arith::IndexCastOp>(loc, targetType, offset);
+    }
+
+    auto srcInt = dyn_cast<IntegerType>(offset.getType());
+    auto dstInt = dyn_cast<IntegerType>(targetType);
+    if (srcInt && dstInt) {
+      if (srcInt.getWidth() < dstInt.getWidth()) {
+        return builder.create<arith::ExtSIOp>(loc, targetType, offset);
+      }
+      return builder.create<arith::TruncIOp>(loc, targetType, offset);
+    }
+
+    llvm_unreachable("unexpected offset type conversion");
+    return nullptr;
+  }
+
+  static Value castOrSplatOffset(Value offset, Type targetType, Location loc,
+                                 OpBuilder &builder) {
+    if (offset.getType() == targetType) {
+      return offset;
+    }
+
+    if (auto targetTensorType = dyn_cast<RankedTensorType>(targetType)) {
+      auto elementType = targetTensorType.getElementType();
+      Value scalarOffset =
+          isa<RankedTensorType>(offset.getType())
+              ? offset
+              : castScalarOffset(offset, elementType, loc, builder);
+      if (scalarOffset.getType() == targetType) {
+        return scalarOffset;
+      }
+      return builder.create<triton::SplatOp>(loc, targetTensorType,
+                                             scalarOffset);
+    }
+
+    return castScalarOffset(offset, targetType, loc, builder);
+  }
 
   LogicalResult processUnstructuredPtrs(unsigned int defaultBitWidth = 32) {
     llvm::SmallDenseSet<Value> ptrArgs;
@@ -282,6 +391,7 @@ public:
 
     llvm::SmallVector<Operation *> toDelete;
     llvm::SmallVector<Operation *> ptrUsers;
+    llvm::SmallVector<OperandReplacement> operandReplacements;
 
     while (!workList.empty()) {
       auto val = workList.front();
@@ -317,20 +427,20 @@ public:
                   return success();
                 })
                 .Case<triton::AddPtrOp>([&](triton::AddPtrOp addptr) {
-                  // Bail when we have an addptr in an scf.if as we  do not know
-                  // if the pointer returning from both branches will have the
-                  // same source
-                  if (addptr->getParentOfType<scf::IfOp>()) {
+                  // Bail only when a pointer escapes an scf.if branch. Pointers
+                  // created and consumed inside the branch can still be lowered
+                  // to the same base+offset form as straight-line code.
+                  if (reachesScfIfYieldThroughDerivedPtrs(addptr.getResult())) {
                     return failure();
                   }
 
                   OpBuilder b{addptr};
                   auto loc = addptr->getLoc();
 
-                  auto offsetInfo = offsetMap.at(addptr.getPtr());
+                  auto offsetInfo = offsetMap.at(addptr->getOperand(0));
 
                   auto prevOff = offsetInfo.offset;
-                  auto off = addptr.getOffset();
+                  auto off = addptr->getOperand(1);
 
                   auto lhsWidth = offsetInfo.bitWidth;
                   auto rhsWidth = getBitWidth(off.getType());
@@ -349,10 +459,12 @@ public:
                   }
 
                   auto accumulatedOff = b.create<arith::AddIOp>(
-                      loc, getPtrOffsetType(addptr.getType(), resWidth),
+                      loc,
+                      getPtrOffsetType(addptr.getResult().getType(), resWidth),
                       prevOff, off);
 
-                  PtrOffset newOffsetInfo{offsetInfo.ptr, addptr.getType(),
+                  PtrOffset newOffsetInfo{offsetInfo.ptr,
+                                          addptr.getResult().getType(),
                                           resWidth, accumulatedOff};
 
                   offsetMap.insert({addptr, newOffsetInfo});
@@ -368,6 +480,9 @@ public:
 
                   if (!triton::isPtrTypeLike(resType)) {
                     return success();
+                  }
+                  if (reachesScfIfYieldThroughDerivedPtrs(res)) {
+                    return failure();
                   }
 
                   auto ptr = op->getOperand(0);
@@ -393,16 +508,44 @@ public:
 
                   return success();
                 })
+                .Case<triton::BitcastOp>([&](triton::BitcastOp bitcast) {
+                  auto res = bitcast.getResult();
+                  auto resType = res.getType();
+                  if (!triton::isPtrTypeLike(resType)) {
+                    return success();
+                  }
+                  if (reachesScfIfYieldThroughDerivedPtrs(res)) {
+                    return failure();
+                  }
+
+                  auto offsetInfo = offsetMap.at(bitcast->getOperand(0));
+                  PtrOffset newOffsetInfo{offsetInfo.ptr, resType,
+                                          offsetInfo.bitWidth,
+                                          offsetInfo.offset};
+
+                  offsetMap.insert({res, newOffsetInfo});
+                  workList.push(res);
+                  toDelete.push_back(bitcast);
+
+                  return success();
+                })
                 .Case<tts::MakeGatherScatterTensorPtrOp>(
-                    [&](Operation *op) { return success(); })
-                .Case<triton::LoadOp, triton::StoreOp, triton::MakeTensorPtrOp,
+                    [&](tts::MakeGatherScatterTensorPtrOp makeGatherScatter) {
+                      Value base = makeGatherScatter->getOperand(0);
+                      if (!ptrArgs.contains(base) && offsetMap.contains(base)) {
+                        ptrUsers.push_back(makeGatherScatter);
+                      }
+                      return success();
+                    })
+                .Case<triton::LoadOp, triton::StoreOp, triton::AtomicRMWOp,
+                      triton::AtomicCASOp, triton::MakeTensorPtrOp,
                       tts::MakeTensorPtrOp>([&](Operation *op) {
                   // Special case:
                   // We do not want to create "unstructured tensor pointer" into
                   // tts.make_tptr if the base pointer is directly from the
                   // kernel arguments.
                   if (auto makeTensorPtr = dyn_cast<tts::MakeTensorPtrOp>(op)) {
-                    if (ptrArgs.contains(makeTensorPtr.getBase())) {
+                    if (ptrArgs.contains(makeTensorPtr->getOperand(0))) {
                       return success();
                     }
                   }
@@ -456,7 +599,45 @@ public:
 
                   return success();
                 })
-                .Case<scf::YieldOp>([](auto) { return success(); })
+                .Case<scf::WhileOp>([&](scf::WhileOp whileOp) {
+                  // scf.while carries loop values through before-region args,
+                  // after-region args, and operation results. Pointer values
+                  // are represented by the original base pointer plus a carried
+                  // integer offset, matching the scf.for handling above.
+                  auto argIndex = use.getOperandNumber();
+                  auto init = whileOp.getInits()[argIndex];
+                  auto offsetInfo = offsetMap.at(init);
+                  auto offsetType =
+                      getPtrOffsetType(offsetInfo.ptrType, offsetInfo.bitWidth);
+
+                  operandReplacements.push_back(
+                      {whileOp.getOperation(), argIndex, offsetInfo.offset});
+
+                  auto beforeArg = whileOp.getBeforeArguments()[argIndex];
+                  beforeArg.setType(offsetType);
+                  PtrOffset beforeArgOffset{offsetInfo.ptr, offsetInfo.ptrType,
+                                            offsetInfo.bitWidth, beforeArg};
+                  offsetMap.insert({beforeArg, beforeArgOffset});
+                  workList.push(beforeArg);
+
+                  auto afterArg = whileOp.getAfterArguments()[argIndex];
+                  afterArg.setType(offsetType);
+                  PtrOffset afterArgOffset{offsetInfo.ptr, offsetInfo.ptrType,
+                                           offsetInfo.bitWidth, afterArg};
+                  offsetMap.insert({afterArg, afterArgOffset});
+                  workList.push(afterArg);
+
+                  auto res = whileOp.getResult(argIndex);
+                  res.setType(offsetType);
+                  PtrOffset resOffset{offsetInfo.ptr, offsetInfo.ptrType,
+                                      offsetInfo.bitWidth, res};
+                  offsetMap.insert({res, resOffset});
+                  workList.push(res);
+
+                  return success();
+                })
+                .Case<scf::ConditionOp, scf::YieldOp>(
+                    [](auto) { return success(); })
                 .Case<triton::CatOp>([](triton::CatOp op) {
                   op->emitError("Do not support gather / scatter with multiple "
                                 "bases yet");
@@ -473,6 +654,11 @@ public:
       }
     }
 
+    for (const auto &replacement : operandReplacements) {
+      replacement.op->setOperand(replacement.operandIndex,
+                                 replacement.replacement);
+    }
+
     for (auto op : ptrUsers) {
       OpBuilder b{op};
       auto loc = op->getLoc();
@@ -480,6 +666,7 @@ public:
           llvm::TypeSwitch<Operation *, LogicalResult>(op)
               .Case<triton::LoadOp>([&](triton::LoadOp load) {
                 auto offsetInfo = offsetMap.at(load.getPtr());
+                Value ptr = materializeBasePtr(offsetInfo, loc, b);
 
                 auto other = load.getOther();
 
@@ -491,9 +678,9 @@ public:
                   }
                 }
 
-                auto gather = b.create<tts::GatherOp>(
-                    loc, load.getType(), offsetInfo.ptr, offsetInfo.offset,
-                    load.getMask(), other);
+                auto gather = b.create<tts::GatherOp>(loc, load.getType(), ptr,
+                                                      offsetInfo.offset,
+                                                      load.getMask(), other);
 
                 load->replaceAllUsesWith(gather->getResults());
                 load->erase();
@@ -501,20 +688,63 @@ public:
               })
               .Case<triton::StoreOp>([&](triton::StoreOp store) {
                 auto offsetInfo = offsetMap.at(store.getPtr());
-                b.create<tts::ScatterOp>(loc, offsetInfo.ptr, offsetInfo.offset,
+                Value ptr = materializeBasePtr(offsetInfo, loc, b);
+                b.create<tts::ScatterOp>(loc, ptr, offsetInfo.offset,
                                          store.getValue(), store.getMask());
                 store->erase();
                 return success();
               })
+              .Case<triton::AtomicRMWOp>([&](triton::AtomicRMWOp atomic) {
+                auto offsetInfo = offsetMap.at(atomic.getPtr());
+                Value ptr = materializeBasePtr(offsetInfo, loc, b);
+                auto rmw = b.create<tts::AtomicRMWOp>(
+                    loc, atomic.getResult().getType(),
+                    atomic.getAtomicRmwOpAttr(), ptr, offsetInfo.offset,
+                    atomic.getVal(), atomic.getMask(), atomic.getSemAttr(),
+                    atomic.getScopeAttr());
+                atomic->replaceAllUsesWith(rmw->getResults());
+                atomic->erase();
+                return success();
+              })
+              .Case<triton::AtomicCASOp>([&](triton::AtomicCASOp atomic) {
+                auto offsetInfo = offsetMap.at(atomic.getPtr());
+                Value ptr = materializeBasePtr(offsetInfo, loc, b);
+                auto cas = b.create<tts::AtomicCASOp>(
+                    loc, atomic.getResult().getType(), ptr, offsetInfo.offset,
+                    atomic.getCmp(), atomic.getVal(), atomic.getSemAttr(),
+                    atomic.getScopeAttr());
+                atomic->replaceAllUsesWith(cas->getResults());
+                atomic->erase();
+                return success();
+              })
+              .Case<tts::MakeGatherScatterTensorPtrOp>(
+                  [&](tts::MakeGatherScatterTensorPtrOp makeGatherScatter) {
+                    auto offsetInfo =
+                        offsetMap.at(makeGatherScatter->getOperand(0));
+                    Value ptr = materializeBasePtr(offsetInfo, loc, b);
+                    Value baseOffset = castOrSplatOffset(
+                        offsetInfo.offset,
+                        makeGatherScatter.getGatherScatterOffset().getType(),
+                        loc, b);
+                    Value accumulatedOffset = b.create<arith::AddIOp>(
+                        loc,
+                        makeGatherScatter.getGatherScatterOffset().getType(),
+                        baseOffset, makeGatherScatter.getGatherScatterOffset());
+
+                    makeGatherScatter->setOperand(0, ptr);
+                    makeGatherScatter->setOperand(1, accumulatedOffset);
+                    return success();
+                  })
               .Case<triton::MakeTensorPtrOp,
                     tts::MakeTensorPtrOp>([&](auto makeTensorPtr) {
                 // For block pointers, the base could come from a sequence of
                 // `tt.addptr`. Accumulate the target offset with the offset
                 // we have saved.
-                auto offsetInfo = offsetMap.at(makeTensorPtr.getBase());
+                auto offsetInfo = offsetMap.at(makeTensorPtr->getOperand(0));
                 auto baseOffset = offsetInfo.offset;
 
-                makeTensorPtr.getBaseMutable().set(offsetInfo.ptr);
+                Value ptr = materializeBasePtr(offsetInfo, loc, b);
+                makeTensorPtr->setOperand(0, ptr);
 
                 // Add the existing offset from the base to the offset
                 // operand in the ops.
@@ -562,7 +792,7 @@ public:
       }
     }
 
-    for (auto op : toDelete) {
+    for (auto op : llvm::reverse(toDelete)) {
       auto ptrInfo = offsetMap.at(op->getResult(0));
       op->replaceAllUsesWith(ValueRange{ptrInfo.offset});
       op->erase();

--- a/lib/Conversion/UnstructuredToMemref/UnstructuredToMemrefPass.cpp
+++ b/lib/Conversion/UnstructuredToMemref/UnstructuredToMemrefPass.cpp
@@ -77,6 +77,108 @@ static MemRefType getMemrefTypeForScalarPtr(triton::PointerType ptrType,
   return memrefType;
 }
 
+static Value getFlatMemref(Location loc, Value ptr, Type elementType,
+                           ConversionPatternRewriter &rewriter) {
+  return rewriter
+      .create<memref::CastOp>(
+          loc, MemRefType::get({ShapedType::kDynamic}, elementType), ptr)
+      .getResult();
+}
+
+static Value createAtomicRMWValue(Location loc, triton::RMWOp rmwOp,
+                                  Value oldValue, Value newValue,
+                                  OpBuilder &builder) {
+  Type type = oldValue.getType();
+  switch (rmwOp) {
+  case triton::RMWOp::AND:
+    return builder.create<arith::AndIOp>(loc, oldValue, newValue);
+  case triton::RMWOp::OR:
+    return builder.create<arith::OrIOp>(loc, oldValue, newValue);
+  case triton::RMWOp::XOR:
+    return builder.create<arith::XOrIOp>(loc, oldValue, newValue);
+  case triton::RMWOp::ADD:
+    if (isa<FloatType>(type))
+      return builder.create<arith::AddFOp>(loc, oldValue, newValue);
+    return builder.create<arith::AddIOp>(loc, oldValue, newValue);
+  case triton::RMWOp::FADD:
+    return builder.create<arith::AddFOp>(loc, oldValue, newValue);
+  case triton::RMWOp::MAX:
+    if (isa<FloatType>(type))
+      return builder.create<arith::MaximumFOp>(loc, oldValue, newValue);
+    return builder.create<arith::MaxSIOp>(loc, oldValue, newValue);
+  case triton::RMWOp::MIN:
+    if (isa<FloatType>(type))
+      return builder.create<arith::MinimumFOp>(loc, oldValue, newValue);
+    return builder.create<arith::MinSIOp>(loc, oldValue, newValue);
+  case triton::RMWOp::UMAX:
+    return builder.create<arith::MaxUIOp>(loc, oldValue, newValue);
+  case triton::RMWOp::UMIN:
+    return builder.create<arith::MinUIOp>(loc, oldValue, newValue);
+  case triton::RMWOp::XCHG:
+    return newValue;
+  }
+  llvm_unreachable("unexpected atomic rmw op");
+}
+
+static Value createAtomicCASValue(Location loc, Value oldValue, Value cmpValue,
+                                  Value newValue, OpBuilder &builder) {
+  Type type = oldValue.getType();
+  Value matched;
+  if (isa<FloatType>(type)) {
+    matched = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OEQ,
+                                            oldValue, cmpValue);
+  } else {
+    matched = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
+                                            oldValue, cmpValue);
+  }
+  return builder.create<arith::SelectOp>(loc, matched, newValue, oldValue);
+}
+
+static Value createZeroValue(Location loc, Type type, OpBuilder &builder) {
+  auto zeroAttr = builder.getZeroAttr(type);
+  assert(zeroAttr && "unexpected element type");
+  return builder.create<arith::ConstantOp>(loc, zeroAttr);
+}
+
+static Value createMaskedLoadOrFallback(Location loc, Value mask,
+                                        Value fallback, Value memref,
+                                        Value index, OpBuilder &builder) {
+  if (!mask) {
+    return builder.create<memref::LoadOp>(loc, memref, ValueRange{index});
+  }
+
+  auto ifOp = builder.create<scf::IfOp>(loc, fallback.getType(), mask,
+                                        /*withElseRegion=*/true);
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
+    Value loaded =
+        builder.create<memref::LoadOp>(loc, memref, ValueRange{index});
+    builder.create<scf::YieldOp>(loc, loaded);
+  }
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
+    builder.create<scf::YieldOp>(loc, fallback);
+  }
+  return ifOp.getResult(0);
+}
+
+template <typename StoreBuilder>
+static void createOptionalMaskedStore(Location loc, Value mask,
+                                      StoreBuilder storeBuilder,
+                                      OpBuilder &builder) {
+  if (!mask) {
+    storeBuilder(builder);
+    return;
+  }
+
+  OpBuilder::InsertionGuard guard(builder);
+  auto ifOp = builder.create<scf::IfOp>(loc, mask);
+  builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
+  storeBuilder(builder);
+}
+
 struct ScalarLoadConverter : public OpConversionPattern<tts::GatherOp> {
   using OpConversionPattern<tts::GatherOp>::OpConversionPattern;
 
@@ -219,10 +321,7 @@ struct GatherConverter : public OpConversionPattern<tts::GatherOp> {
 
     Value fallback = gatherOp.getOther();
     if (!fallback) {
-      auto elemType = resultType.getElementType();
-      auto zeroAttr = rewriter.getZeroAttr(elemType);
-      assert(zeroAttr && "unexpected element type");
-      fallback = rewriter.create<arith::ConstantOp>(loc, zeroAttr);
+      fallback = createZeroValue(loc, resultType.getElementType(), rewriter);
     }
 
     auto c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
@@ -237,14 +336,15 @@ struct GatherConverter : public OpConversionPattern<tts::GatherOp> {
             b.create<tensor::ExtractOp>(nestedLoc, offsetTensor, indices);
         Value index0 =
             b.create<arith::IndexCastOp>(nestedLoc, b.getIndexType(), offset);
-        Value loadValue =
-            b.create<memref::LoadOp>(nestedLoc, baseMemref, ValueRange{index0});
-        Value value = loadValue;
+        Value value;
         if (gatherOp.getMask()) {
-          Value mask =
-              b.create<tensor::ExtractOp>(nestedLoc, gatherOp.getMask(), indices);
-          value = b.create<arith::SelectOp>(nestedLoc, mask, loadValue, fallback)
-                      .getResult();
+          Value mask = b.create<tensor::ExtractOp>(nestedLoc,
+                                                   gatherOp.getMask(), indices);
+          value = createMaskedLoadOrFallback(nestedLoc, mask, fallback,
+                                             baseMemref, index0, b);
+        } else {
+          value = b.create<memref::LoadOp>(nestedLoc, baseMemref,
+                                           ValueRange{index0});
         }
         return b.create<tensor::InsertOp>(nestedLoc, value, tensorAcc, indices)
             .getResult();
@@ -299,7 +399,12 @@ struct ScatterConverter : public OpConversionPattern<tts::ScatterOp> {
       return failure();
     }
 
-    auto valueType = dyn_cast<RankedTensorType>(scatterOp.getValue().getType());
+    auto offsetRankedType = dyn_cast<RankedTensorType>(offsetTensor.getType());
+    auto valueType = dyn_cast<RankedTensorType>(valueTensor.getType());
+    if (!offsetRankedType || !valueType ||
+        offsetRankedType.getRank() != valueType.getRank()) {
+      return failure();
+    }
 
     // Treat the base pointer (memref) as 1D because the offsets are all
     // relative to a single base pointer (already collapsed).
@@ -311,64 +416,276 @@ struct ScatterConverter : public OpConversionPattern<tts::ScatterOp> {
                                     ptr)
             .getResult();
 
-    // The linalg.generic op should have the following inputs:
-    // - the offset tensor.
-    // - the value tensor.
-    // - an optional mask tensor if the scatter op contains mask.
-    SmallVector<Value> inputs{offsetTensor, valueTensor};
-
-    if (scatterOp.getMask()) {
-      inputs.push_back(scatterOp.getMask());
+    Value maskTensor = scatterOp.getMask() ? adaptor.getMask() : Value();
+    if (maskTensor) {
+      auto maskType = dyn_cast<RankedTensorType>(maskTensor.getType());
+      if (!maskType || maskType.getRank() != valueType.getRank())
+        return failure();
     }
 
-    // Affine maps for the inputs.
-    SmallVector<AffineMap> affineMaps(
-        inputs.size(), rewriter.getMultiDimIdentityMap(valueType.getRank()));
+    SmallVector<Value> loopBounds;
+    loopBounds.reserve(offsetRankedType.getRank());
+    for (int64_t i = 0, e = offsetRankedType.getRank(); i < e; ++i) {
+      if (offsetRankedType.isDynamicDim(i)) {
+        loopBounds.push_back(
+            rewriter.create<tensor::DimOp>(loc, offsetTensor, i));
+      } else {
+        loopBounds.push_back(rewriter.create<arith::ConstantIndexOp>(
+            loc, offsetRankedType.getShape()[i]));
+      }
+    }
 
-    // All iterator types are parallel.
-    SmallVector<utils::IteratorType> iteratorTypes(
-        valueType.getRank(), utils::IteratorType::parallel);
+    auto c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    auto c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
-    rewriter.setInsertionPoint(scatterOp);
+    auto buildLoopNest = [&](auto &&self, OpBuilder &b, Location nestedLoc,
+                             int64_t dim, SmallVector<Value> &indices) -> void {
+      if (dim == offsetRankedType.getRank()) {
+        Value offsetValue =
+            b.create<tensor::ExtractOp>(nestedLoc, offsetTensor, indices);
+        Value index = b.create<arith::IndexCastOp>(nestedLoc, b.getIndexType(),
+                                                   offsetValue);
+        Value value =
+            b.create<tensor::ExtractOp>(nestedLoc, valueTensor, indices);
+        Value maskValue =
+            maskTensor
+                ? b.create<tensor::ExtractOp>(nestedLoc, maskTensor, indices)
+                      .getResult()
+                : Value();
+        createOptionalMaskedStore(
+            nestedLoc, maskValue,
+            [&](OpBuilder &storeBuilder) {
+              storeBuilder.create<memref::StoreOp>(nestedLoc, value, baseMemref,
+                                                   ValueRange{index});
+            },
+            b);
+        return;
+      }
 
-    auto genericOp = rewriter.create<linalg::GenericOp>(
-        loc, TypeRange{}, inputs, ValueRange{}, affineMaps, iteratorTypes,
-        [&](OpBuilder &b, Location loc, ValueRange args) {
-          auto storeValueAtIndex = [baseMemref](OpBuilder &b, Location loc,
-                                                Value index, Value value) {
-            Value index0 =
-                b.create<arith::IndexCastOp>(loc, b.getIndexType(), index);
+      auto loop = b.create<scf::ForOp>(nestedLoc, c0, loopBounds[dim], c1);
+      OpBuilder nestedBuilder = OpBuilder::atBlockBegin(loop.getBody());
+      indices.push_back(loop.getInductionVar());
+      self(self, nestedBuilder, nestedLoc, dim + 1, indices);
+      indices.pop_back();
+    };
 
-            b.create<memref::StoreOp>(loc, value, baseMemref,
-                                      ValueRange{index0});
-          };
-
-          auto offset = args[0];
-          auto value = args[1];
-
-          if (!scatterOp.getMask()) {
-            // If there is no mask, simply insert the current value to the
-            // base memref using its offset.
-            storeValueAtIndex(b, loc, offset, value);
-          } else {
-            // Keep the linalg.generic body single-block; mask false preserves
-            // the existing destination value.
-            auto mask = args[2];
-            Value index0 =
-                b.create<arith::IndexCastOp>(loc, b.getIndexType(), offset);
-            Value oldValue =
-                b.create<memref::LoadOp>(loc, baseMemref, ValueRange{index0});
-            Value selected =
-                b.create<arith::SelectOp>(loc, mask, value, oldValue);
-            b.create<memref::StoreOp>(loc, selected, baseMemref,
-                                      ValueRange{index0});
-          }
-
-          b.create<linalg::YieldOp>(loc);
-        });
+    SmallVector<Value> indices;
+    buildLoopNest(buildLoopNest, rewriter, loc, 0, indices);
 
     rewriter.eraseOp(scatterOp);
 
+    return success();
+  }
+};
+
+struct AtomicRMWConverter : public OpConversionPattern<tts::AtomicRMWOp> {
+  using OpConversionPattern<tts::AtomicRMWOp>::OpConversionPattern;
+
+  AtomicRMWConverter(const TypeConverter &typeConverter, MLIRContext *context)
+      : OpConversionPattern<tts::AtomicRMWOp>(typeConverter, context) {}
+
+  LogicalResult
+  matchAndRewrite(tts::AtomicRMWOp atomicOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = atomicOp->getLoc();
+    auto ptr = adaptor.getPtr();
+    auto offset = adaptor.getOffset();
+    auto value = adaptor.getVal();
+    auto mask = adaptor.getMask();
+    auto offsetType = dyn_cast<ShapedType>(offset.getType());
+
+    if (!offsetType) {
+      auto resultType = atomicOp.getResult().getType();
+      Value baseMemref = getFlatMemref(loc, ptr, resultType, rewriter);
+      Value index = rewriter.create<arith::IndexCastOp>(
+          loc, rewriter.getIndexType(), offset);
+      Value fallback = createZeroValue(loc, resultType, rewriter);
+      Value oldValue = createMaskedLoadOrFallback(loc, mask, fallback,
+                                                  baseMemref, index, rewriter);
+      Value storedValue = createAtomicRMWValue(loc, atomicOp.getAtomicRmwOp(),
+                                               oldValue, value, rewriter);
+      createOptionalMaskedStore(
+          loc, mask,
+          [&](OpBuilder &b) {
+            b.create<memref::StoreOp>(loc, storedValue, baseMemref,
+                                      ValueRange{index});
+          },
+          rewriter);
+      rewriter.replaceOp(atomicOp, oldValue);
+      return success();
+    }
+
+    auto resultType =
+        dyn_cast<RankedTensorType>(atomicOp.getResult().getType());
+    auto valueType = dyn_cast<RankedTensorType>(atomicOp.getVal().getType());
+    if (!resultType || !valueType) {
+      return failure();
+    }
+
+    Value baseMemref =
+        getFlatMemref(loc, ptr, resultType.getElementType(), rewriter);
+    Value resultTensor = rewriter.create<tensor::EmptyOp>(
+        loc, resultType.getShape(), resultType.getElementType());
+
+    SmallVector<Value> loopBounds;
+    loopBounds.reserve(resultType.getRank());
+    for (int64_t i = 0, e = resultType.getRank(); i < e; ++i) {
+      if (resultType.isDynamicDim(i)) {
+        loopBounds.push_back(rewriter.create<tensor::DimOp>(loc, value, i));
+      } else {
+        loopBounds.push_back(rewriter.create<arith::ConstantIndexOp>(
+            loc, resultType.getShape()[i]));
+      }
+    }
+
+    auto c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    auto c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+    auto buildLoopNest = [&](auto &&self, OpBuilder &b, Location nestedLoc,
+                             int64_t dim, SmallVector<Value> &indices,
+                             Value tensorAcc) -> Value {
+      if (dim == resultType.getRank()) {
+        Value offsetValue =
+            b.create<tensor::ExtractOp>(nestedLoc, offset, indices);
+        Value index = b.create<arith::IndexCastOp>(nestedLoc, b.getIndexType(),
+                                                   offsetValue);
+        Value maskValue =
+            mask ? b.create<tensor::ExtractOp>(nestedLoc, mask, indices)
+                       .getResult()
+                 : Value();
+        Value fallback =
+            createZeroValue(nestedLoc, resultType.getElementType(), b);
+        Value oldValue = createMaskedLoadOrFallback(
+            nestedLoc, maskValue, fallback, baseMemref, index, b);
+        Value newValue = b.create<tensor::ExtractOp>(nestedLoc, value, indices);
+        Value storedValue = createAtomicRMWValue(
+            nestedLoc, atomicOp.getAtomicRmwOp(), oldValue, newValue, b);
+        createOptionalMaskedStore(
+            nestedLoc, maskValue,
+            [&](OpBuilder &storeBuilder) {
+              storeBuilder.create<memref::StoreOp>(
+                  nestedLoc, storedValue, baseMemref, ValueRange{index});
+            },
+            b);
+        return b
+            .create<tensor::InsertOp>(nestedLoc, oldValue, tensorAcc, indices)
+            .getResult();
+      }
+
+      auto loop = b.create<scf::ForOp>(nestedLoc, c0, loopBounds[dim], c1,
+                                       ValueRange{tensorAcc});
+      auto *body = loop.getBody();
+      OpBuilder nestedBuilder = OpBuilder::atBlockBegin(body);
+      indices.push_back(loop.getInductionVar());
+      Value nextTensor = self(self, nestedBuilder, nestedLoc, dim + 1, indices,
+                              loop.getRegionIterArgs()[0]);
+      indices.pop_back();
+      nestedBuilder.create<scf::YieldOp>(nestedLoc, nextTensor);
+      return loop.getResult(0);
+    };
+
+    SmallVector<Value> indices;
+    Value result =
+        buildLoopNest(buildLoopNest, rewriter, loc, 0, indices, resultTensor);
+    rewriter.replaceOp(atomicOp, result);
+    return success();
+  }
+};
+
+struct AtomicCASConverter : public OpConversionPattern<tts::AtomicCASOp> {
+  using OpConversionPattern<tts::AtomicCASOp>::OpConversionPattern;
+
+  AtomicCASConverter(const TypeConverter &typeConverter, MLIRContext *context)
+      : OpConversionPattern<tts::AtomicCASOp>(typeConverter, context) {}
+
+  LogicalResult
+  matchAndRewrite(tts::AtomicCASOp atomicOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = atomicOp->getLoc();
+    auto ptr = adaptor.getPtr();
+    auto offset = adaptor.getOffset();
+    auto cmp = adaptor.getCmp();
+    auto value = adaptor.getVal();
+    auto offsetType = dyn_cast<ShapedType>(offset.getType());
+
+    if (!offsetType) {
+      auto resultType = atomicOp.getResult().getType();
+      Value baseMemref = getFlatMemref(loc, ptr, resultType, rewriter);
+      Value index = rewriter.create<arith::IndexCastOp>(
+          loc, rewriter.getIndexType(), offset);
+      Value oldValue =
+          rewriter.create<memref::LoadOp>(loc, baseMemref, ValueRange{index});
+      Value storedValue =
+          createAtomicCASValue(loc, oldValue, cmp, value, rewriter);
+      rewriter.create<memref::StoreOp>(loc, storedValue, baseMemref,
+                                       ValueRange{index});
+      rewriter.replaceOp(atomicOp, oldValue);
+      return success();
+    }
+
+    auto resultType =
+        dyn_cast<RankedTensorType>(atomicOp.getResult().getType());
+    auto valueType = dyn_cast<RankedTensorType>(atomicOp.getVal().getType());
+    if (!resultType || !valueType) {
+      return failure();
+    }
+
+    Value baseMemref =
+        getFlatMemref(loc, ptr, resultType.getElementType(), rewriter);
+    Value resultTensor = rewriter.create<tensor::EmptyOp>(
+        loc, resultType.getShape(), resultType.getElementType());
+
+    SmallVector<Value> loopBounds;
+    loopBounds.reserve(resultType.getRank());
+    for (int64_t i = 0, e = resultType.getRank(); i < e; ++i) {
+      if (resultType.isDynamicDim(i)) {
+        loopBounds.push_back(rewriter.create<tensor::DimOp>(loc, value, i));
+      } else {
+        loopBounds.push_back(rewriter.create<arith::ConstantIndexOp>(
+            loc, resultType.getShape()[i]));
+      }
+    }
+
+    auto c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    auto c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+    auto buildLoopNest = [&](auto &&self, OpBuilder &b, Location nestedLoc,
+                             int64_t dim, SmallVector<Value> &indices,
+                             Value tensorAcc) -> Value {
+      if (dim == resultType.getRank()) {
+        Value offsetValue =
+            b.create<tensor::ExtractOp>(nestedLoc, offset, indices);
+        Value index = b.create<arith::IndexCastOp>(nestedLoc, b.getIndexType(),
+                                                   offsetValue);
+        Value oldValue =
+            b.create<memref::LoadOp>(nestedLoc, baseMemref, ValueRange{index});
+        Value cmpValue = b.create<tensor::ExtractOp>(nestedLoc, cmp, indices);
+        Value newValue = b.create<tensor::ExtractOp>(nestedLoc, value, indices);
+        Value storedValue =
+            createAtomicCASValue(nestedLoc, oldValue, cmpValue, newValue, b);
+        b.create<memref::StoreOp>(nestedLoc, storedValue, baseMemref,
+                                  ValueRange{index});
+        return b
+            .create<tensor::InsertOp>(nestedLoc, oldValue, tensorAcc, indices)
+            .getResult();
+      }
+
+      auto loop = b.create<scf::ForOp>(nestedLoc, c0, loopBounds[dim], c1,
+                                       ValueRange{tensorAcc});
+      auto *body = loop.getBody();
+      OpBuilder nestedBuilder = OpBuilder::atBlockBegin(body);
+      indices.push_back(loop.getInductionVar());
+      Value nextTensor = self(self, nestedBuilder, nestedLoc, dim + 1, indices,
+                              loop.getRegionIterArgs()[0]);
+      indices.pop_back();
+      nestedBuilder.create<scf::YieldOp>(nestedLoc, nextTensor);
+      return loop.getResult(0);
+    };
+
+    SmallVector<Value> indices;
+    Value result =
+        buildLoopNest(buildLoopNest, rewriter, loc, 0, indices, resultTensor);
+    rewriter.replaceOp(atomicOp, result);
     return success();
   }
 };
@@ -398,12 +715,14 @@ public:
         bufferization::BufferizationDialect, memref::MemRefDialect,
         ttx::TritonTilingExtDialect>();
 
-    target.addIllegalOp<tts::GatherOp, tts::ScatterOp>();
+    target.addIllegalOp<tts::GatherOp, tts::ScatterOp, tts::AtomicRMWOp,
+                        tts::AtomicCASOp>();
 
     PtrToUnrankedMemrefConverter typeConverter;
 
     patterns.add<GatherConverter, ScatterConverter, ScalarLoadConverter,
-                 ScalarStoreConverter>(typeConverter, patterns.getContext());
+                 ScalarStoreConverter, AtomicRMWConverter, AtomicCASConverter>(
+        typeConverter, patterns.getContext());
 
     if (failed(applyPartialConversion(moduleOp, target, std::move(patterns))))
       signalPassFailure();

--- a/test/Conversion/StructuredToMemref/wraparound_linear_stride.mlir
+++ b/test/Conversion/StructuredToMemref/wraparound_linear_stride.mlir
@@ -1,0 +1,26 @@
+// RUN: triton-shared-opt --split-input-file --structured-to-memref %s | FileCheck %s
+
+module {
+  tt.func public @wrap_linear_load_non_unit_stride(%arg0: !tt.ptr<f32>, %offset: index, %modulo: index, %stride: index) -> tensor<4xf32> {
+    %0 = tts.make_tptr %arg0 to sizes: [4], strides: [%stride], offsets: [%offset], shape: [%modulo], order: [] : <f32> to tensor<4x!tt.ptr<f32>>
+    %1 = "tts.load"(%0) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<4x!tt.ptr<f32>>) -> tensor<4xf32>
+    tt.return %1 : tensor<4xf32>
+  }
+}
+
+// CHECK-LABEL:   tt.func public @wrap_linear_load_non_unit_stride(
+// CHECK-SAME:        %[[PTR:.*]]: !tt.ptr<f32>, %[[OFFSET:.*]]: index, %[[MODULO:.*]]: index, %[[STRIDE:.*]]: index)
+// CHECK:           %[[BASE:.*]] = builtin.unrealized_conversion_cast %[[PTR]] : !tt.ptr<f32> to memref<*xf32>
+// CHECK:           %[[C4:.*]] = arith.constant 4 : index
+// CHECK:           %[[START:.*]] = arith.remsi %[[OFFSET]], %[[MODULO]] : index
+// CHECK:           %[[REMAINING:.*]] = arith.subi %[[MODULO]], %[[START]] : index
+// CHECK:           %[[C1:.*]] = arith.constant 1 : index
+// CHECK:           %[[STRIDE_MINUS_ONE:.*]] = arith.subi %[[STRIDE]], %[[C1]] : index
+// CHECK:           %[[NUMERATOR:.*]] = arith.addi %[[REMAINING]], %[[STRIDE_MINUS_ONE]] : index
+// CHECK:           %[[ELEMENTS_UNTIL_WRAP:.*]] = arith.divsi %[[NUMERATOR]], %[[STRIDE]] : index
+// CHECK:           %[[D1:.*]] = arith.minsi %[[C4]], %[[ELEMENTS_UNTIL_WRAP]] : index
+// CHECK:           %[[D2:.*]] = arith.subi %[[C4]], %[[D1]] : index
+// CHECK:           %[[ZERO:.*]] = arith.constant 0 : index
+// CHECK:           %[[CAST0:.*]] = memref.reinterpret_cast %[[BASE]] to offset: {{\[}}%[[START]]], sizes: {{\[}}%[[D1]]], strides: {{\[}}%[[STRIDE]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:           %[[CAST1:.*]] = memref.reinterpret_cast %[[BASE]] to offset: {{\[}}%[[ZERO]]], sizes: {{\[}}%[[D2]]], strides: {{\[}}%[[STRIDE]]] : memref<*xf32> to memref<?xf32, strided<[?], offset: ?>>
+// CHECK:           builtin.unrealized_conversion_cast %[[CAST0]], %[[CAST1]] : memref<?xf32, strided<[?], offset: ?>>, memref<?xf32, strided<[?], offset: ?>> to tensor<4x!tt.ptr<f32>> {wrap_linear}

--- a/test/Conversion/TritonToUnstructured/scf_if_derived_ptr_escape.mlir
+++ b/test/Conversion/TritonToUnstructured/scf_if_derived_ptr_escape.mlir
@@ -1,0 +1,28 @@
+// RUN: triton-shared-opt --triton-to-unstructured %s 2>&1 | FileCheck %s
+
+module {
+  tt.func public @if_yields_bitcast_addptr(%arg0: !tt.ptr<i32>, %cond: i1) -> !tt.ptr<i64> {
+    %c1_i32 = arith.constant 1 : i32
+    %0 = scf.if %cond -> (!tt.ptr<i64>) {
+      %1 = tt.addptr %arg0, %c1_i32 : !tt.ptr<i32>, i32
+      %2 = tt.bitcast %1 : !tt.ptr<i32> -> !tt.ptr<i64>
+      scf.yield %2 : !tt.ptr<i64>
+    } else {
+      %1 = tt.bitcast %arg0 : !tt.ptr<i32> -> !tt.ptr<i64>
+      scf.yield %1 : !tt.ptr<i64>
+    }
+    tt.return %0 : !tt.ptr<i64>
+  }
+}
+
+// CHECK: warning: Cannot transform tensor of pointers into a single base pointer with tensor of offsets
+// CHECK-LABEL: tt.func public @if_yields_bitcast_addptr
+// CHECK:         %[[IF:.*]] = scf.if
+// CHECK:           %[[ADDPTR:.*]] = tt.addptr
+// CHECK:           %[[BITCAST:.*]] = tt.bitcast %[[ADDPTR]]
+// CHECK:           scf.yield %[[BITCAST]] : !tt.ptr<i64>
+// CHECK:         } else {
+// CHECK:           %[[ELSE:.*]] = tt.bitcast
+// CHECK:           scf.yield %[[ELSE]] : !tt.ptr<i64>
+// CHECK:         }
+// CHECK:         tt.return %[[IF]] : !tt.ptr<i64>

--- a/test/Conversion/UnstructuredToMemref/gather_scatter_all_mask.mlir
+++ b/test/Conversion/UnstructuredToMemref/gather_scatter_all_mask.mlir
@@ -29,7 +29,6 @@ module {
   }
 }
 
-// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
 // CHECK:         tt.func public @masked_gather_scatter([[PARAM_0_:%.+]]: !tt.ptr<f32>, [[PARAM_1_:%.+]]: !tt.ptr<f32>) attributes {noinline = false} {
 // CHECK-DAG:       [[VAR_cst_:%.+]] = arith.constant dense<3> : tensor<4xi32>
 // CHECK-DAG:       [[VAR_cst_0_:%.+]] = arith.constant dense<64> : tensor<4xi32>
@@ -49,19 +48,19 @@ module {
 // CHECK-DAG:         [[VAR_7_:%.+]] = arith.cmpi slt, [[VAR_6_]], [[VAR_cst_0_]] : tensor<4xi32>
 // CHECK-DAG:         [[VAR_cast_:%.+]] = memref.cast [[VAR_1_]] : memref<*xf32> to memref<?xf32>
 // CHECK:             scf.for
-// CHECK:             tensor.extract
-// CHECK:             memref.load
-// CHECK:             arith.select
-// CHECK:             tensor.insert
+// CHECK:               tensor.extract
+// CHECK:               scf.if
+// CHECK:                 memref.load
+// CHECK:               tensor.insert
 // CHECK:             [[VAR_cast_3_:%.+]] = memref.cast [[VAR_0_]] : memref<*xf32> to memref<?xf32>
-// CHECK:             linalg.generic {indexing_maps = [[[MAP_0_]], [[MAP_0_]], [[MAP_0_]]], iterator_types = ["parallel"]} ins([[VAR_6_]], {{.*}}, [[VAR_7_]] : tensor<4xi32>, tensor<4xf32>, tensor<4xi1>) {
-// CHECK:             ^bb0([[IN_3_:%.+]]: i32, [[IN_4_:%.+]]: f32, [[IN_5_:%.+]]: i1):
-// CHECK:               [[VAR_17_:%.+]] = arith.index_cast [[IN_3_]] : i32 to index
-// CHECK:               [[VAR_old_:%.+]] = memref.load [[VAR_cast_3_]]{{.}}[[VAR_17_]]{{.}} : memref<?xf32>
-// CHECK:               [[VAR_selected_store_:%.+]] = arith.select [[IN_5_]], [[IN_4_]], [[VAR_old_]] : f32
-// CHECK:               memref.store [[VAR_selected_store_]], [[VAR_cast_3_]]{{.}}[[VAR_17_]]{{.}} : memref<?xf32>
-// CHECK:               linalg.yield
-// CHECK:             }
+// CHECK:             scf.for [[VAR_ARG5:%.+]] =
+// CHECK:               [[VAR_OFFSET:%.+]] = tensor.extract [[VAR_6_]]{{.}}[[VAR_ARG5]]{{.}} : tensor<4xi32>
+// CHECK:               [[VAR_INDEX:%.+]] = arith.index_cast [[VAR_OFFSET]] : i32 to index
+// CHECK:               [[VAR_VALUE:%.+]] = tensor.extract {{.*}}{{.}}[[VAR_ARG5]]{{.}} : tensor<4xf32>
+// CHECK:               [[VAR_MASK:%.+]] = tensor.extract [[VAR_7_]]{{.}}[[VAR_ARG5]]{{.}} : tensor<4xi1>
+// CHECK:               scf.if [[VAR_MASK]] {
+// CHECK:                 memref.store [[VAR_VALUE]], [[VAR_cast_3_]]{{.}}[[VAR_INDEX]]{{.}} : memref<?xf32>
+// CHECK:               }
 // CHECK-DAG:         [[VAR_11_:%.+]] = arith.addi [[VAR_6_]], [[VAR_cst_1_]] : tensor<4xi32>
 // CHECK-DAG:         [[VAR_12_:%.+]] = arith.addi [[VAR_arg4_]], [[VAR_cst_1_]] : tensor<4xi32>
 // CHECK:             scf.yield [[VAR_11_]], [[VAR_12_]] : tensor<4xi32>, tensor<4xi32>

--- a/tools/triton-shared-opt/RegisterTritonSharedDialects.h
+++ b/tools/triton-shared-opt/RegisterTritonSharedDialects.h
@@ -1,11 +1,14 @@
 #pragma once
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Ptr/IR/PtrDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
@@ -47,5 +50,6 @@ inline void registerTritonSharedDialects(mlir::DialectRegistry &registry) {
       mlir::math::MathDialect, mlir::arith::ArithDialect, mlir::scf::SCFDialect,
       mlir::linalg::LinalgDialect, mlir::func::FuncDialect,
       mlir::tensor::TensorDialect, mlir::memref::MemRefDialect,
-      mlir::bufferization::BufferizationDialect>();
+      mlir::bufferization::BufferizationDialect, mlir::affine::AffineDialect,
+      mlir::vector::VectorDialect, mlir::LLVM::LLVMDialect>();
 }


### PR DESCRIPTION
# Summary
This PR enhances the TritonStructured dialect and improves the robustness of its lowering passes to support more
complex pointer operations and control flow.

## Key Changes:

- Dialect Enhancements: Added tts.atomic_rmw and tts.atomic_cas operations to TritonStructured to support atomic
  memory operations through unstructured pointers.
- Improved Conversions:
  - StructuredToMemref: Added support for 1D split (linear wraparound) pointers.
  - TritonToUnstructured:
    - Added support for scf.while loops.
    - Improved handling of triton.bitcast, triton.atomic_rmw, and triton.atomic_cas.
    - Fixed robustness issues related to scf.if yield through derived pointers.
  - UnstructuredToMemref:
    - Replaced linalg.generic based scatter lowering with scf.for loops to better handle complex masking and
      atomics.
    - Implemented lowering for the new tts.atomic_rmw and tts.atomic_cas operations.
- Analysis & Tools:
  - Refined PtrAnalysis and updated RegisterTritonSharedDialects for better dialect integration.
  - Added unit tests for wraparound linear strides and pointer escape scenarios in scf.if.

## Technical Details:

- The transition from linalg.generic to explicit loops in UnstructuredToMemref allows for more flexible code
  generation, especially when dealing with atomic operations and complex mask logic that was previously difficult to
  express in a purely declarative Linalg way.
- Expanded split_ptr support to rank-1 tensors, enabling more generic linear memory wraparound handling.
