### PR TITLE
fix(linalg): improve dot, reduce, and scan lowering

### DIFF
--- a/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
+++ b/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.hpp
@@ -934,11 +934,13 @@ struct CatConverter : public OpConversionPattern<triton::CatOp> {
   LogicalResult
   matchAndRewrite(triton::CatOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto operands = adaptor.getOperands();
+    if (operands.empty())
+      return failure();
+
     auto replacement = rewriter.create<tensor::ConcatOp>(
-        op.getLoc(), 0 /* concat dimension */, adaptor.getOperands());
-
-    rewriter.replaceOp(op, replacement);
-
+        op.getLoc(), op.getType(), (uint64_t)0, operands);
+    rewriter.replaceOp(op, replacement.getResult());
     return success();
   }
 };
@@ -988,7 +990,9 @@ struct JoinConverter : public OpConversionPattern<triton::JoinOp> {
   LogicalResult
   matchAndRewrite(triton::JoinOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    ValueRange inputs = op.getOperands();
+    auto inputs = adaptor.getOperands();
+    if (inputs.size() != 2)
+      return failure();
 
     auto resultType = cast<RankedTensorType>(op.getResult().getType());
 
@@ -997,20 +1001,18 @@ struct JoinConverter : public OpConversionPattern<triton::JoinOp> {
         loc, resultType.getShape(), resultType.getElementType());
 
     auto shape = resultType.getShape();
+    int64_t rank = resultType.getRank();
 
-    SmallVector<OpFoldResult> offsets(shape.size(), rewriter.getIndexAttr(0));
-    SmallVector<OpFoldResult> strides(shape.size(), rewriter.getIndexAttr(1));
+    SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
     SmallVector<OpFoldResult> sizes = llvm::to_vector(
         llvm::map_range(shape, [&](int64_t dim) -> OpFoldResult {
           return rewriter.getIndexAttr(dim);
         }));
 
     for (int i = 0; i < 2; ++i) {
-      offsets.pop_back();
-      sizes.pop_back();
-
-      offsets.push_back(rewriter.getIndexAttr(i));
-      sizes.push_back(rewriter.getIndexAttr(1));
+      offsets[rank - 1] = rewriter.getIndexAttr(i);
+      sizes[rank - 1] = rewriter.getIndexAttr(1);
       result = rewriter.create<tensor::InsertSliceOp>(loc, inputs[i], result,
                                                       offsets, sizes, strides);
     }
@@ -1072,9 +1074,9 @@ struct MatmulConverter : public OpConversionPattern<triton::DotOp> {
   matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto opa = op.getA();
-    auto opb = op.getB();
-    auto opc = op.getC();
+    auto opa = adaptor.getA();
+    auto opb = adaptor.getB();
+    auto opc = adaptor.getC();
 
     auto dstType = cast<RankedTensorType>(op.getType());
     auto elementType = dstType.getElementType();
@@ -1099,6 +1101,20 @@ struct MatmulConverter : public OpConversionPattern<triton::DotOp> {
     // to the i32 accumulator type.  Without it the op verifier rejects the IR.
     Value res;
     auto aElemType = cast<RankedTensorType>(opa.getType()).getElementType();
+
+    if (!integers && aElemType != elementType) {
+      // Promote float operands to accumulator type
+      auto opaType = cast<RankedTensorType>(opa.getType());
+      auto promotedAType =
+          RankedTensorType::get(opaType.getShape(), elementType);
+      opa = rewriter.create<arith::ExtFOp>(loc, promotedAType, opa);
+
+      auto opbType = cast<RankedTensorType>(opb.getType());
+      auto promotedBType =
+          RankedTensorType::get(opbType.getShape(), elementType);
+      opb = rewriter.create<arith::ExtFOp>(loc, promotedBType, opb);
+    }
+
     bool isMixedIntPrecision = integers && (aElemType != elementType);
     if (isMixedIntPrecision) {
       auto castAttr = linalg::TypeFnAttr::get(rewriter.getContext(),
@@ -1205,25 +1221,45 @@ private:
                                               attr);
   }
 
-  bool requiresF32Conversion(const Type elemType, Operation *redOp) const {
-    unsigned width =
-        cast<FloatType>(Float32Type::get(elemType.getContext())).getWidth();
-    return isa<FloatType>(elemType) &&
-           elemType.getIntOrFloatBitWidth() < width &&
-           isa<arith::AddFOp>(redOp);
+  bool requiresF32Conversion(Type type, Operation *redOp) const {
+    if (auto shapedType = dyn_cast<ShapedType>(type))
+      type = shapedType.getElementType();
+    if (auto floatType = dyn_cast<FloatType>(type)) {
+      bool widthOk = floatType.getWidth() < 32;
+      bool opOk = isa<arith::AddFOp>(redOp) || isa<arith::MulFOp>(redOp) ||
+                  isa<arith::MaximumFOp>(redOp) ||
+                  isa<arith::MinimumFOp>(redOp);
+      return widthOk && opOk;
+    }
+    return false;
   }
 
   Value getRedElement(Value lhs, Value rhs, const Location loc,
                       Operation *redOp, OpBuilder &b,
                       const bool convertLhsToF32Precision) const {
+    Type accType = rhs.getType();
+    if (auto addf = dyn_cast<arith::AddFOp>(redOp)) {
+      if (lhs.getType() != accType)
+        lhs = b.create<arith::ExtFOp>(loc, accType, lhs);
+      return b.create<arith::AddFOp>(loc, lhs, rhs, addf.getFastmathAttr());
+    }
+    if (auto mulf = dyn_cast<arith::MulFOp>(redOp)) {
+      if (lhs.getType() != accType)
+        lhs = b.create<arith::ExtFOp>(loc, accType, lhs);
+      return b.create<arith::MulFOp>(loc, lhs, rhs, mulf.getFastmathAttr());
+    }
+    if (auto maxf = dyn_cast<arith::MaximumFOp>(redOp)) {
+      if (lhs.getType() != accType)
+        lhs = b.create<arith::ExtFOp>(loc, accType, lhs);
+      return b.create<arith::MaximumFOp>(loc, lhs, rhs, maxf.getFastmathAttr());
+    }
+    if (auto minf = dyn_cast<arith::MinimumFOp>(redOp)) {
+      if (lhs.getType() != accType)
+        lhs = b.create<arith::ExtFOp>(loc, accType, lhs);
+      return b.create<arith::MinimumFOp>(loc, lhs, rhs, minf.getFastmathAttr());
+    }
+
     return llvm::TypeSwitch<Operation *, Value>(redOp)
-        .Case<arith::AddFOp, arith::MulFOp>([&](auto redOp) {
-          if (convertLhsToF32Precision) {
-            lhs = b.create<arith::ExtFOp>(loc, Float32Type::get(b.getContext()),
-                                          lhs);
-          }
-          return b.create<decltype(redOp)>(loc, lhs, rhs);
-        })
         .Case<arith::AddIOp, arith::AndIOp, arith::XOrIOp, arith::MaximumFOp,
               arith::MaxNumFOp, arith::MulIOp, arith::MinimumFOp,
               arith::MinNumFOp, arith::MinSIOp, arith::MinUIOp, arith::MaxSIOp,
@@ -1237,40 +1273,54 @@ private:
         });
   }
 
+  SmallVector<Value> cloneReduceBody(triton::ReduceOp op, ValueRange current,
+                                     ValueRange accumulated, OpBuilder &builder,
+                                     Location loc) const {
+    Block *reduceBlock = op.getBody();
+    IRMapping mapping;
+    for (auto [arg, value] :
+         llvm::zip_equal(reduceBlock->getArguments().take_front(current.size()),
+                         accumulated)) {
+      mapping.map(arg, value);
+    }
+    for (auto [arg, value] : llvm::zip_equal(
+             reduceBlock->getArguments().drop_front(current.size()), current)) {
+      mapping.map(arg, value);
+    }
+
+    for (auto &innerOp : reduceBlock->without_terminator())
+      builder.clone(innerOp, mapping);
+
+    auto terminator =
+        cast<triton::ReduceReturnOp>(reduceBlock->getTerminator());
+    return llvm::map_to_vector(terminator.getOperands(), [&](Value operand) {
+      return mapping.lookup(operand);
+    });
+  }
+
   LogicalResult
   convertToLinalgReduce(triton::ReduceOp op,
                         typename triton::ReduceOp::Adaptor adaptor,
                         ConversionPatternRewriter &rewriter) const {
-    auto source = adaptor.getOperands().front();
-    auto sourceType = cast<RankedTensorType>(source.getType());
-    auto elemType = sourceType.getElementType();
-    auto resType = op.getResult().front().getType();
+    SmallVector<Value> operands(adaptor.getOperands().begin(),
+                                adaptor.getOperands().end());
+    if (operands.empty())
+      return failure();
+
+    auto firstSource = operands.front();
+    auto firstSourceType = cast<RankedTensorType>(firstSource.getType());
     auto loc = op.getLoc();
     auto reductionOps = getRedOps(op);
 
-    // Reduction of arbitrary operations isn't supported because using the first
-    // element across the reduction dimension requires us to iterate over a
-    // subview that skips over each first element.
-    if (reductionOps.size() != 1 ||
-        !isReductionOpSupported(reductionOps.front())) {
-      return rewriter.notifyMatchFailure(
-          op, "Only support lowering reduction with body "
-              "containing 1 max(i/f), addf, ori, or mulf.");
-    }
-
-    auto rop = reductionOps.front();
     auto axis = op.getAxis();
-    auto rank = sourceType.getRank();
+    auto rank = firstSourceType.getRank();
     auto isVectorReduce = (rank == 1);
+    auto resType = op.getResult().front().getType();
 
     // For now we are transposing reductions from Triton Shared as an
     // optimization. This should not be the job of Triton Shared so moving
-    // forward this will be removed. Doing the transpose here lacks a wider
-    // scope of analysis that might indicate that the transpose to a given axis
-    // is not optimal.
+    // forward this will be removed.
     if (transposeToRank0) {
-      // if it is not a vector reduce, we can transpose the source
-      // so that the reduction axis is the first dimension.
       if (!isVectorReduce && axis != 0) {
         SmallVector<int32_t> order;
         order.reserve(rank);
@@ -1280,70 +1330,152 @@ private:
             order.push_back(i);
           }
         }
-        source = getTransposedValue(source, op.getLoc(), rewriter, order);
+        for (Value &operand : operands) {
+          operand = getTransposedValue(operand, loc, rewriter, order);
+        }
         axis = 0;
       }
     } else {
-      // preserving old behavior until we remove the transpose entirely.
       if (axis == rank - 1 && !isVectorReduce) {
-        source = getTransposedValue(source, op.getLoc(), rewriter);
+        for (Value &operand : operands) {
+          operand = getTransposedValue(operand, loc, rewriter);
+        }
         axis = rank - 2;
       }
     }
 
-    bool convertToF32Precision = requiresF32Conversion(resType, rop);
+    // Determine if we can use a simple initialization with linalg.fill
+    bool isSimpleReduction =
+        (reductionOps.size() == 1 && operands.size() == 1 &&
+         isReductionOpSupported(reductionOps.front()));
 
-    auto constantType = convertToF32Precision
-                            ? Float32Type::get(rewriter.getContext())
-                            : elemType;
+    SmallVector<Value> initTensors;
+    SmallVector<Value> reductionInputs;
 
-    auto accBaseConstOp = getRedBaseConstOp(rewriter, rop, constantType);
-    Value initTensor;
+    if (isSimpleReduction) {
+      auto rop = reductionOps.front();
+      auto resType = op.getResult().front().getType();
+      bool convertToF32Precision = requiresF32Conversion(resType, rop);
+      auto constantType = convertToF32Precision
+                              ? Float32Type::get(rewriter.getContext())
+                              : firstSourceType.getElementType();
+      auto accBaseConstOp = getRedBaseConstOp(rewriter, rop, constantType);
 
-    if (isVectorReduce) {
-      // The affine vectorizer cannot vectorize affine loops generated from
-      // linalg.reduce for the vector reduce case, so we must rewrite the
-      // linalg.reduce to affine loops manually. Here we lower to AllocTensor
-      // directly instead of EmptyOp so that the subsequent pass can recognize
-      // the patterns (EmptyOp is susceptible to being CSE'd away, making it
-      // harder to match the patterns correctly).
-      initTensor = rewriter.create<bufferization::AllocTensorOp>(
-          loc, RankedTensorType::get({}, constantType), ValueRange{});
-      initTensor = rewriter.create<tensor::InsertOp>(loc, accBaseConstOp,
-                                                     initTensor, ValueRange{});
+      if (isVectorReduce) {
+        Value init = rewriter.create<tensor::EmptyOp>(
+            loc, RankedTensorType::get({}, constantType), ValueRange{});
+        initTensors.push_back(
+            rewriter
+                .create<linalg::FillOp>(loc, ValueRange{accBaseConstOp},
+                                        ValueRange{init})
+                .result());
+      } else {
+        Value init = rewriter.create<tensor::EmptyOp>(
+            loc, cast<RankedTensorType>(resType).getShape(), constantType);
+        initTensors.push_back(
+            rewriter
+                .create<linalg::FillOp>(loc, ValueRange{accBaseConstOp},
+                                        ValueRange{init})
+                .result());
+      }
+      reductionInputs.push_back(operands.front());
     } else {
-      Value init = rewriter.create<tensor::EmptyOp>(
-          loc, cast<RankedTensorType>(resType).getShape(), constantType);
-      initTensor = rewriter
-                       .create<linalg::FillOp>(loc, ValueRange{accBaseConstOp},
-                                               ValueRange{init})
-                       .result();
+      // Generic reduction: use the first element along reduction axis as init
+      for (auto [input, result] : llvm::zip_equal(operands, op.getResults())) {
+        auto inputType = cast<RankedTensorType>(input.getType());
+        auto resType = result.getType();
+        auto shape = inputType.getShape();
+
+        // Slice first element along axis
+        SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
+        SmallVector<OpFoldResult> sizes;
+        for (int64_t i = 0; i < rank; ++i) {
+          if (i == axis) {
+            sizes.push_back(rewriter.getIndexAttr(1));
+          } else if (inputType.isDynamicDim(i)) {
+            sizes.push_back(
+                rewriter.create<tensor::DimOp>(loc, input, i).getResult());
+          } else {
+            sizes.push_back(rewriter.getIndexAttr(shape[i]));
+          }
+        }
+        SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
+
+        SmallVector<int64_t> slicedShape;
+        for (int i = 0; i < rank; ++i) {
+          if (i != axis)
+            slicedShape.push_back(shape[i]);
+        }
+        auto slicedType =
+            RankedTensorType::get(slicedShape, inputType.getElementType());
+
+        Value first = rewriter.create<tensor::ExtractSliceOp>(
+            loc, slicedType, input, offsets, sizes, strides);
+        initTensors.push_back(first);
+
+        // Slice remaining elements
+        offsets[axis] = rewriter.getIndexAttr(1);
+        SmallVector<int64_t> restShape(shape.begin(), shape.end());
+        if (inputType.isDynamicDim(axis)) {
+          Value axisSize = rewriter.create<tensor::DimOp>(loc, input, axis);
+          Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+          sizes[axis] =
+              rewriter.create<arith::SubIOp>(loc, axisSize, one).getResult();
+          restShape[axis] = ShapedType::kDynamic;
+        } else {
+          sizes[axis] = rewriter.getIndexAttr(shape[axis] - 1);
+          restShape[axis] -= 1;
+        }
+        auto restRankedType =
+            RankedTensorType::get(restShape, inputType.getElementType());
+
+        Value rest = rewriter.create<tensor::ExtractSliceOp>(
+            loc, restRankedType, input, offsets, sizes, strides);
+        reductionInputs.push_back(rest);
+      }
     }
 
-    Value finalResult =
-        rewriter
-            .create<linalg::ReduceOp>(
-                loc, ValueRange{source}, ValueRange{initTensor},
-                SmallVector<int64_t>{axis},
-                [&](OpBuilder &opBuilder, Location loc, ValueRange inputs) {
-                  assert(inputs.size() == 2);
-                  Value result =
-                      getRedElement(inputs[0], inputs[1], loc, rop, opBuilder,
-                                    convertToF32Precision);
-                  opBuilder.create<linalg::YieldOp>(loc, result);
-                })
-            .getResult(0);
+    auto linalgOp = rewriter.create<linalg::ReduceOp>(
+        loc, reductionInputs, initTensors, SmallVector<int64_t>{axis},
+        [&](OpBuilder &b, Location loc, ValueRange inputs) {
+          // inputs are [ins..., outs...]
+          unsigned numInputs = reductionInputs.size();
+          ValueRange current = inputs.take_front(numInputs);
+          ValueRange accumulated = inputs.drop_front(numInputs);
 
-    if (isVectorReduce) {
-      finalResult =
-          rewriter.create<tensor::ExtractOp>(loc, constantType, finalResult);
+          if (isSimpleReduction) {
+            auto rop = reductionOps.front();
+            Value result =
+                getRedElement(current[0], accumulated[0], loc, rop, b,
+                              requiresF32Conversion(resType, rop));
+            b.create<linalg::YieldOp>(loc, result);
+          } else {
+            SmallVector<Value> nextAccs =
+                cloneReduceBody(op, current, accumulated, b, loc);
+            b.create<linalg::YieldOp>(loc, nextAccs);
+          }
+        });
+
+    SmallVector<Value> finalResults;
+    for (auto [res, tritonRes] :
+         llvm::zip_equal(linalgOp.getResults(), op.getResults())) {
+      Value val = res;
+      if (isVectorReduce) {
+        val = rewriter.create<tensor::ExtractOp>(loc, val, ValueRange{});
+      }
+
+      // Handle precision conversion for the simple path if it was used
+      if (isSimpleReduction) {
+        auto rop = reductionOps.front();
+        auto resType = op.getResult().front().getType();
+        if (requiresF32Conversion(resType, rop)) {
+          val = rewriter.create<arith::TruncFOp>(loc, resType, val);
+        }
+      }
+      finalResults.push_back(val);
     }
 
-    if (convertToF32Precision) {
-      finalResult = rewriter.create<arith::TruncFOp>(loc, resType, finalResult);
-    }
-
-    rewriter.replaceOp(op, finalResult);
+    rewriter.replaceOp(op, finalResults);
     return success();
   }
 
@@ -1506,7 +1638,12 @@ class ArgMinMaxBaseConverter : public OpConversionPattern<triton::ReduceOp> {
   }
 
 public:
-  ArgMinMaxBaseConverter(MLIRContext *context) : OpConversionPattern(context) {}
+  ArgMinMaxBaseConverter(MLIRContext *context, bool transposeToRank0 = true)
+      : OpConversionPattern<triton::ReduceOp>(context),
+        transposeToRank0(transposeToRank0) {}
+
+private:
+  bool transposeToRank0;
 
   LogicalResult
   matchAndRewrite(ReduceOp op, OpAdaptor adaptor,
@@ -1572,6 +1709,38 @@ public:
 
     auto elemTypes = op.getElementTypes();
 
+    SmallVector<Value> operands(adaptor.getOperands().begin(),
+                                adaptor.getOperands().end());
+    auto axis = adaptor.getAxis();
+    auto firstSource = operands.front();
+    auto firstSourceType = cast<RankedTensorType>(firstSource.getType());
+    auto rank = firstSourceType.getRank();
+    auto isVectorReduce = (rank == 1);
+
+    if (transposeToRank0) {
+      if (!isVectorReduce && axis != 0) {
+        SmallVector<int32_t> order;
+        order.reserve(rank);
+        order.push_back(axis);
+        for (int i = 0; i < rank; ++i) {
+          if (i != axis) {
+            order.push_back(i);
+          }
+        }
+        for (Value &operand : operands) {
+          operand = getTransposedValue(operand, loc, rewriter, order);
+        }
+        axis = 0;
+      }
+    } else {
+      if (axis == rank - 1 && !isVectorReduce) {
+        for (Value &operand : operands) {
+          operand = getTransposedValue(operand, loc, rewriter);
+        }
+        axis = rank - 2;
+      }
+    }
+
     // Set the initial value of the rank-0 tensor containing
     // the result value to either -inf or +inf depending on
     // whether we're dealing with argmax or argmin
@@ -1600,8 +1769,7 @@ public:
         getInitTensor(rewriter, reductionResultShape, indicesAccBaseVal, loc)};
 
     auto linalgOp = rewriter.create<linalg::ReduceOp>(
-        loc, adaptor.getOperands(), outputs,
-        SmallVector<int64_t>{adaptor.getAxis()},
+        loc, operands, outputs, SmallVector<int64_t>{axis},
         [&](OpBuilder &b, Location loc, ValueRange inputs) {
           assert(inputs.size() == 4);
 
@@ -1662,7 +1830,8 @@ struct ArgMaxConverter : public ArgMinMaxBaseConverter<ArgMaxConverter> {
     return -std::numeric_limits<float>::infinity();
   }
 
-  ArgMaxConverter(MLIRContext *context) : ArgMinMaxBaseConverter(context) {}
+  ArgMaxConverter(MLIRContext *context, bool transposeToRank0 = true)
+      : ArgMinMaxBaseConverter(context, transposeToRank0) {}
 };
 
 struct ArgMinConverter : public ArgMinMaxBaseConverter<ArgMinConverter> {
@@ -1693,7 +1862,8 @@ struct ArgMinConverter : public ArgMinMaxBaseConverter<ArgMinConverter> {
     return std::numeric_limits<float>::infinity();
   }
 
-  ArgMinConverter(MLIRContext *context) : ArgMinMaxBaseConverter(context) {}
+  ArgMinConverter(MLIRContext *context, bool transposeToRank0 = true)
+      : ArgMinMaxBaseConverter(context, transposeToRank0) {}
 };
 
 // get_program_id and get_num_programs:
@@ -1869,66 +2039,234 @@ struct DenseConstantConverter : public OpConversionPattern<arith::ConstantOp> {
 class CumSumConverter : public OpConversionPattern<triton::ScanOp> {
   using OpConversionPattern<triton::ScanOp>::OpConversionPattern;
 
-  // CumSum is a specific instance of Scan that looks like the following:
-  //       %1 = "tt.scan"(%0) <{axis = 1 : i32}> ({
-  //       ^bb0(%arg0: f32, %arg1: f32):
-  //         %2 = arith.addf %arg0, %arg1 : f32
-  //         tt.scan.return %2 : f32
-  //       }) : (tensor<4x4xf32>) -> tensor<4x4xf32>
-  bool isCumSum(triton::ScanOp op) const {
-    auto scanBlock = op.getBody();
-    auto ops = llvm::map_to_vector(scanBlock->without_terminator(),
-                                   [](Operation &op) { return &op; });
-
-    if (ops.size() != 1) {
-      return false;
+  SmallVector<Value> cloneScanBody(triton::ScanOp op, ValueRange accumulated,
+                                   ValueRange current,
+                                   OpBuilder &builder) const {
+    Block *scanBlock = op.getBody();
+    IRMapping mapping;
+    for (auto [arg, value] : llvm::zip_equal(
+             scanBlock->getArguments().take_front(accumulated.size()),
+             accumulated)) {
+      mapping.map(arg, value);
+    }
+    for (auto [arg, value] : llvm::zip_equal(
+             scanBlock->getArguments().drop_front(accumulated.size()),
+             current)) {
+      mapping.map(arg, value);
     }
 
-    auto addOp = ops.front();
-    if (isa<arith::AddFOp, arith::AddIOp>(addOp)) {
-      if (addOp->getResult(0) != scanBlock->getTerminator()->getOperand(0)) {
-        return false;
-      }
+    for (auto &innerOp : scanBlock->without_terminator())
+      builder.clone(innerOp, mapping);
 
-      auto blockArgs =
-          llvm::map_range(scanBlock->getArguments(), [](BlockArgument arg) {
-            return dyn_cast<Value>(arg);
-          });
-
-      auto addArgs = addOp->getOperands();
-
-      return DenseSet<Value>(blockArgs.begin(), blockArgs.end()) ==
-             DenseSet<Value>(addArgs.begin(), addArgs.end());
-    }
-
-    return false;
+    auto terminator = cast<triton::ScanReturnOp>(scanBlock->getTerminator());
+    return llvm::map_to_vector(terminator.getOperands(), [&](Value operand) {
+      return mapping.lookup(operand);
+    });
   }
 
 public:
   LogicalResult
   matchAndRewrite(triton::ScanOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!isCumSum(op)) {
+    ValueRange inputs = adaptor.getSrcs();
+    if (inputs.empty())
+      return failure();
+
+    unsigned numSrcs = inputs.size();
+    if (op.getNumResults() != numSrcs) {
       return rewriter.notifyMatchFailure(
-          op, "Only support cumsum variant of scan op");
+          op, "scan lowering expects one result per input");
     }
 
-    auto input = op.getOperand(0);
-    auto axis = op.getAxis();
-    auto type = dyn_cast<RankedTensorType>(input.getType());
+    Block *scanBlock = op.getBody();
+    if (scanBlock->getNumArguments() != numSrcs * 2) {
+      return rewriter.notifyMatchFailure(
+          op, "scan combine block argument count mismatch");
+    }
 
-    if (type.getRank() != 1 && type.getRank() != 2 &&
+    auto axis = op.getAxis();
+    auto type = dyn_cast<RankedTensorType>(inputs.front().getType());
+    if (!type)
+      return failure();
+    bool reverse = op.getReverse();
+
+    if ((type.getRank() != 1 && type.getRank() != 2) ||
         axis != type.getRank() - 1) {
       return rewriter.notifyMatchFailure(
-          op, "Only support lowering scan op to cumsum with rank "
+          op, "Only support lowering scan op with rank "
               "= {1, 2} and axis = rank - 1");
     }
 
-    Value init = rewriter.create<tensor::EmptyOp>(op.getLoc(), type.getShape(),
-                                                  type.getElementType());
+    if (llvm::any_of(type.getShape(), ShapedType::isDynamic))
+      return rewriter.notifyMatchFailure(
+          op, "Only support lowering scan op with static shape");
 
-    rewriter.replaceOpWithNewOp<ttx::CumSumOp>(
-        op, input, rewriter.getUI32IntegerAttr(axis), init);
+    if (type.getDimSize(axis) <= 0)
+      return rewriter.notifyMatchFailure(
+          op, "Only support lowering scan op with non-empty scan axis");
+
+    for (Value input : inputs) {
+      auto inputType = dyn_cast<RankedTensorType>(input.getType());
+      if (!inputType || inputType.getRank() != type.getRank() ||
+          inputType.getShape() != type.getShape()) {
+        return rewriter.notifyMatchFailure(
+            op, "scan inputs must have the same static shape");
+      }
+    }
+
+    Location loc = op.getLoc();
+    int64_t rank = type.getRank();
+    ArrayRef<int64_t> shape = type.getShape();
+
+    SmallVector<Value> initTensors;
+    initTensors.reserve(op.getNumResults());
+    for (Value result : op.getResults()) {
+      auto resultType = dyn_cast<RankedTensorType>(result.getType());
+      if (!resultType || resultType.getRank() != rank ||
+          resultType.getShape() != shape) {
+        return rewriter.notifyMatchFailure(
+            op, "scan results must have the same static shape as inputs");
+      }
+      initTensors.push_back(rewriter.create<tensor::EmptyOp>(
+          loc, resultType.getShape(), resultType.getElementType()));
+    }
+
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+    auto getScanIndex = [&](OpBuilder &builder, Value extent,
+                            Value iter) -> Value {
+      if (!reverse)
+        return iter;
+      Value fromEnd = builder.create<arith::SubIOp>(loc, extent, iter);
+      return builder.create<arith::SubIOp>(loc, fromEnd, c1);
+    };
+
+    if (rank == 1) {
+      Value n = rewriter.create<arith::ConstantIndexOp>(loc, shape[0]);
+      Value firstIndex =
+          reverse ? rewriter.create<arith::ConstantIndexOp>(loc, shape[0] - 1)
+                  : c0;
+
+      SmallVector<Value> initialAccs;
+      initialAccs.reserve(numSrcs);
+      for (Value input : inputs)
+        initialAccs.push_back(rewriter.create<tensor::ExtractOp>(
+            loc, input, ValueRange{firstIndex}));
+
+      SmallVector<Value> firstResults;
+      firstResults.reserve(numSrcs);
+      for (auto [initTensor, initialAcc] :
+           llvm::zip_equal(initTensors, initialAccs)) {
+        firstResults.push_back(rewriter.create<tensor::InsertOp>(
+            loc, initialAcc, initTensor, ValueRange{firstIndex}));
+      }
+
+      SmallVector<Value> iterArgs = initialAccs;
+      iterArgs.append(firstResults.begin(), firstResults.end());
+
+      auto loop = rewriter.create<scf::ForOp>(loc, c1, n, c1, iterArgs);
+      {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(loop.getBody());
+        Value i = loop.getInductionVar();
+        Value scanIndex = getScanIndex(rewriter, n, i);
+
+        SmallVector<Value> current;
+        current.reserve(numSrcs);
+        for (Value input : inputs)
+          current.push_back(rewriter.create<tensor::ExtractOp>(
+              loc, input, ValueRange{scanIndex}));
+
+        SmallVector<Value> nextAccs =
+            cloneScanBody(op, loop.getRegionIterArgs().take_front(numSrcs),
+                          current, rewriter);
+
+        SmallVector<Value> nextResults;
+        nextResults.reserve(numSrcs);
+        for (auto [resultTensor, nextAcc] : llvm::zip_equal(
+                 loop.getRegionIterArgs().drop_front(numSrcs), nextAccs)) {
+          nextResults.push_back(rewriter.create<tensor::InsertOp>(
+              loc, nextAcc, resultTensor, ValueRange{scanIndex}));
+        }
+
+        SmallVector<Value> yieldValues = nextAccs;
+        yieldValues.append(nextResults.begin(), nextResults.end());
+        rewriter.create<scf::YieldOp>(loc, yieldValues);
+      }
+
+      SmallVector<Value> results;
+      for (Value result : loop.getResults().drop_front(numSrcs))
+        results.push_back(result);
+      rewriter.replaceOp(op, results);
+      return success();
+    }
+
+    Value m = rewriter.create<arith::ConstantIndexOp>(loc, shape[0]);
+    Value n = rewriter.create<arith::ConstantIndexOp>(loc, shape[1]);
+    Value firstIndex =
+        reverse ? rewriter.create<arith::ConstantIndexOp>(loc, shape[1] - 1)
+                : c0;
+    auto outerLoop = rewriter.create<scf::ForOp>(loc, c0, m, c1, initTensors);
+    {
+      OpBuilder::InsertionGuard outerGuard(rewriter);
+      rewriter.setInsertionPointToStart(outerLoop.getBody());
+      Value i = outerLoop.getInductionVar();
+
+      SmallVector<Value> initialAccs;
+      initialAccs.reserve(numSrcs);
+      for (Value input : inputs)
+        initialAccs.push_back(rewriter.create<tensor::ExtractOp>(
+            loc, input, ValueRange{i, firstIndex}));
+
+      SmallVector<Value> firstResults;
+      firstResults.reserve(numSrcs);
+      for (auto [outputTensor, initialAcc] :
+           llvm::zip_equal(outerLoop.getRegionIterArgs(), initialAccs)) {
+        firstResults.push_back(rewriter.create<tensor::InsertOp>(
+            loc, initialAcc, outputTensor, ValueRange{i, firstIndex}));
+      }
+
+      SmallVector<Value> iterArgs = initialAccs;
+      iterArgs.append(firstResults.begin(), firstResults.end());
+
+      auto innerLoop = rewriter.create<scf::ForOp>(loc, c1, n, c1, iterArgs);
+      {
+        OpBuilder::InsertionGuard innerGuard(rewriter);
+        rewriter.setInsertionPointToStart(innerLoop.getBody());
+        Value j = innerLoop.getInductionVar();
+        Value scanIndex = getScanIndex(rewriter, n, j);
+
+        SmallVector<Value> current;
+        current.reserve(numSrcs);
+        for (Value input : inputs)
+          current.push_back(rewriter.create<tensor::ExtractOp>(
+              loc, input, ValueRange{i, scanIndex}));
+
+        SmallVector<Value> nextAccs =
+            cloneScanBody(op, innerLoop.getRegionIterArgs().take_front(numSrcs),
+                          current, rewriter);
+
+        SmallVector<Value> nextResults;
+        nextResults.reserve(numSrcs);
+        for (auto [resultTensor, nextAcc] : llvm::zip_equal(
+                 innerLoop.getRegionIterArgs().drop_front(numSrcs), nextAccs)) {
+          nextResults.push_back(rewriter.create<tensor::InsertOp>(
+              loc, nextAcc, resultTensor, ValueRange{i, scanIndex}));
+        }
+
+        SmallVector<Value> yieldValues = nextAccs;
+        yieldValues.append(nextResults.begin(), nextResults.end());
+        rewriter.create<scf::YieldOp>(loc, yieldValues);
+      }
+
+      SmallVector<Value> outerYieldValues;
+      for (Value result : innerLoop.getResults().drop_front(numSrcs))
+        outerYieldValues.push_back(result);
+      rewriter.create<scf::YieldOp>(loc, outerYieldValues);
+    }
+
+    rewriter.replaceOp(op, outerLoop.getResults());
 
     return success();
   }

--- a/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
+++ b/lib/Conversion/TritonArithToLinalg/TritonArithToLinalg.cpp
@@ -92,8 +92,8 @@ void mlir::triton::populateTritonArithToLinalgConversionPatterns(
   // the first elements along the reduction axis and perform the reduction on
   // the remaining elements. However, this results in creatings sub-tensors that
   // aren't always multiple of 2s, which are sub-optimal for certain hardwares.
-  patterns.add<ArgMinConverter>(patterns.getContext());
-  patterns.add<ArgMaxConverter>(patterns.getContext());
+  patterns.add<ArgMinConverter>(patterns.getContext(), transposeReduceToRank0);
+  patterns.add<ArgMaxConverter>(patterns.getContext(), transposeReduceToRank0);
   patterns.add<ReduceConverter>(patterns.getContext(), transposeReduceToRank0);
 
   // Note: the ordering here matters!

--- a/test/Conversion/StructuredToMemref/convert_addi_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_addi_reduce.mlir
@@ -21,9 +21,9 @@
 // CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
 // CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : i32) outs(%[[EMPTY_0]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK:           %[[ALLOC_TENSOR_0:.*]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           %[[INSERT_0:.*]] = tensor.insert %[[CONSTANT_0]] into %[[ALLOC_TENSOR_0]][] : tensor<i32>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FILL_0]] : tensor<4096xi32>) outs(%[[INSERT_0]] : tensor<i32>) dimensions = [0]
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<i32>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_0]] : i32) outs(%[[EMPTY_1]] : tensor<i32>) -> tensor<i32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FILL_0]] : tensor<4096xi32>) outs(%[[FILL_1]] : tensor<i32>) dimensions = [0]
 // CHECK:             (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) {
 // CHECK:               %[[ADDI_0:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:               linalg.yield %[[ADDI_0]] : i32

--- a/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/StructuredToMemref/convert_argmin_argmax_2d.mlir
@@ -62,10 +62,13 @@
 // CHECK:           ^bb0(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32):
 // CHECK:             linalg.yield %[[VAL_1]] : i32
 // CHECK:           } -> tensor<4x4xi32>
-// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<4xf32>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_2]] : tensor<4xf32>) -> tensor<4xf32>
+// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<4x4xf32>
+// CHECK:           %[[TRANSPOSE_0:.*]] = linalg.transpose ins(%[[TO_TENSOR_0]] : tensor<4x4xf32>) outs(%[[EMPTY_2]] : tensor<4x4xf32>) permutation = [1, 0]
+// CHECK:           %[[TRANSPOSE_1:.*]] = linalg.transpose ins(%[[GENERIC_1]] : tensor<4x4xi32>) outs(%[[EMPTY_1]] : tensor<4x4xi32>) permutation = [1, 0]
+// CHECK:           %[[EMPTY_3:.*]] = tensor.empty() : tensor<4xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_3]] : tensor<4xf32>) -> tensor<4xf32>
 // CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_1]] : i32) outs(%[[EMPTY_0]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:           %[[REDUCE_0:.*]]:2 = linalg.reduce ins(%[[TO_TENSOR_0]], %[[GENERIC_1]] : tensor<4x4xf32>, tensor<4x4xi32>) outs(%[[FILL_0]], %[[FILL_1]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
+// CHECK:           %[[REDUCE_0:.*]]:2 = linalg.reduce ins(%[[TRANSPOSE_0]], %[[TRANSPOSE_1]] : tensor<4x4xf32>, tensor<4x4xi32>) outs(%[[FILL_0]], %[[FILL_1]] : tensor<4xf32>, tensor<4xi32>) dimensions = [0]
 // CHECK:             (%[[VAL_3:.*]]: f32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: f32, %[[VAL_6:.*]]: i32) {
 // CHECK:               %[[CMPF_0:.*]] = arith.cmpf oeq, %[[VAL_3]], %[[VAL_5]] : f32
 // CHECK:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_4]], %[[VAL_6]] : i32
@@ -76,7 +79,7 @@
 // CHECK:               %[[SELECT_1:.*]] = arith.select %[[ORI_0]], %[[VAL_4]], %[[VAL_6]] : i32
 // CHECK:               linalg.yield %[[SELECT_0]], %[[SELECT_1]] : f32, i32
 // CHECK:             }
-// CHECK:           %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[REDUCE_0]]#1 : tensor<4xi32>) outs(%[[EMPTY_2]] : tensor<4xf32>) {
+// CHECK:           %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[REDUCE_0]]#1 : tensor<4xi32>) outs(%[[EMPTY_3]] : tensor<4xf32>) {
 // CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: f32):
 // CHECK:             %[[SITOFP_0:.*]] = arith.sitofp %[[VAL_7]] : i32 to f32
 // CHECK:             linalg.yield %[[SITOFP_0]] : f32
@@ -176,10 +179,13 @@ module {
 // CHECK:           ^bb0(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32):
 // CHECK:             linalg.yield %[[VAL_1]] : i32
 // CHECK:           } -> tensor<4x4xi32>
-// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<4xf32>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_2]] : tensor<4xf32>) -> tensor<4xf32>
+// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<4x4xf32>
+// CHECK:           %[[TRANSPOSE_0:.*]] = linalg.transpose ins(%[[TO_TENSOR_0]] : tensor<4x4xf32>) outs(%[[EMPTY_2]] : tensor<4x4xf32>) permutation = [1, 0]
+// CHECK:           %[[TRANSPOSE_1:.*]] = linalg.transpose ins(%[[GENERIC_1]] : tensor<4x4xi32>) outs(%[[EMPTY_1]] : tensor<4x4xi32>) permutation = [1, 0]
+// CHECK:           %[[EMPTY_3:.*]] = tensor.empty() : tensor<4xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_3]] : tensor<4xf32>) -> tensor<4xf32>
 // CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_1]] : i32) outs(%[[EMPTY_0]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:           %[[REDUCE_0:.*]]:2 = linalg.reduce ins(%[[TO_TENSOR_0]], %[[GENERIC_1]] : tensor<4x4xf32>, tensor<4x4xi32>) outs(%[[FILL_0]], %[[FILL_1]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
+// CHECK:           %[[REDUCE_0:.*]]:2 = linalg.reduce ins(%[[TRANSPOSE_0]], %[[TRANSPOSE_1]] : tensor<4x4xf32>, tensor<4x4xi32>) outs(%[[FILL_0]], %[[FILL_1]] : tensor<4xf32>, tensor<4xi32>) dimensions = [0]
 // CHECK:             (%[[VAL_3:.*]]: f32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: f32, %[[VAL_6:.*]]: i32) {
 // CHECK:               %[[CMPF_0:.*]] = arith.cmpf oeq, %[[VAL_3]], %[[VAL_5]] : f32
 // CHECK:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[VAL_4]], %[[VAL_6]] : i32
@@ -190,7 +196,7 @@ module {
 // CHECK:               %[[SELECT_1:.*]] = arith.select %[[ORI_0]], %[[VAL_4]], %[[VAL_6]] : i32
 // CHECK:               linalg.yield %[[SELECT_0]], %[[SELECT_1]] : f32, i32
 // CHECK:             }
-// CHECK:           %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_3]], #[[$ATTR_3]]], iterator_types = ["parallel"]} ins(%[[REDUCE_0]]#1 : tensor<4xi32>) outs(%[[EMPTY_2]] : tensor<4xf32>) {
+// CHECK:           %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_3]], #[[$ATTR_3]]], iterator_types = ["parallel"]} ins(%[[REDUCE_0]]#1 : tensor<4xi32>) outs(%[[EMPTY_3]] : tensor<4xf32>) {
 // CHECK:           ^bb0(%[[VAL_7:.*]]: i32, %[[VAL_8:.*]]: f32):
 // CHECK:             %[[SITOFP_0:.*]] = arith.sitofp %[[VAL_7]] : i32 to f32
 // CHECK:             linalg.yield %[[SITOFP_0]] : f32

--- a/test/Conversion/StructuredToMemref/convert_minmax_fp_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_minmax_fp_reduce.mlir
@@ -12,21 +12,30 @@ module {
     tt.return
   }
 }
-
-// CHECK-LABEL:  func.func @maxnumf
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<4096xf32>) -> tensor<4096xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[in_:%.+]]: f32, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_3_:%.+]] = arith.maxnumf [[in_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_3_]] : f32
+// CHECK-LABEL:   func.func @maxnumf(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xf32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0xFF800000 : f32
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_0]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<f32>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_1]] : f32) outs(%[[EMPTY_1]] : tensor<f32>) -> tensor<f32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FILL_0]] : tensor<4096xf32>) outs(%[[FILL_1]] : tensor<f32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32) {
+// CHECK:               %[[MAXNUMF_0:.*]] = arith.maxnumf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK:               linalg.yield %[[MAXNUMF_0]] : f32
 // CHECK:             }
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[REDUCE_0]][] : tensor<f32>
+// CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1]>>
+// CHECK:           affine.store %[[EXTRACT_0]], %[[REINTERPRET_CAST_0]][0] : memref<1xf32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }
 
 
 // -----
@@ -44,18 +53,27 @@ module {
     tt.return
   }
 }
-
-// CHECK-LABEL:  func.func @minnumf
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0x7F800000 : f32
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<4096xf32>) -> tensor<4096xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[in_:%.+]]: f32, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_3_:%.+]] = arith.minnumf [[in_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_3_]] : f32
+// CHECK-LABEL:   func.func @minnumf(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xf32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 0x7F800000 : f32
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_0]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<f32>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_1]] : f32) outs(%[[EMPTY_1]] : tensor<f32>) -> tensor<f32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FILL_0]] : tensor<4096xf32>) outs(%[[FILL_1]] : tensor<f32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32) {
+// CHECK:               %[[MINNUMF_0:.*]] = arith.minnumf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK:               linalg.yield %[[MINNUMF_0]] : f32
 // CHECK:             }
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[REDUCE_0]][] : tensor<f32>
+// CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1]>>
+// CHECK:           affine.store %[[EXTRACT_0]], %[[REINTERPRET_CAST_0]][0] : memref<1xf32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/convert_minmax_reduce.mlir
+++ b/test/Conversion/StructuredToMemref/convert_minmax_reduce.mlir
@@ -12,21 +12,30 @@ module {
     tt.return
   }
 }
-
-// CHECK-LABEL:  func.func @minmax_sgt
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_minus_2147483648_:%.+]] = arith.constant -2147483648 : i32
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_minus_2147483648_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
-// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
-// CHECK:               [[VAR_3_:%.+]] = arith.maxsi [[in_]], [[init_]] : i32
-// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK-LABEL:   func.func @minmax_sgt(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xi32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant -2147483648 : i32
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : i32) outs(%[[EMPTY_0]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<i32>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_1]] : i32) outs(%[[EMPTY_1]] : tensor<i32>) -> tensor<i32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FILL_0]] : tensor<4096xi32>) outs(%[[FILL_1]] : tensor<i32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) {
+// CHECK:               %[[MAXSI_0:.*]] = arith.maxsi %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:               linalg.yield %[[MAXSI_0]] : i32
 // CHECK:             }
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[REDUCE_0]][] : tensor<i32>
+// CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
+// CHECK:           affine.store %[[EXTRACT_0]], %[[REINTERPRET_CAST_0]][0] : memref<1xi32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }
 
 
 // -----
@@ -46,19 +55,29 @@ module {
 }
 
 
-// CHECK-LABEL:  func.func @minmax_ugt
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
-// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
-// CHECK:               [[VAR_3_:%.+]] = arith.maxui [[in_]], [[init_]] : i32
-// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK-LABEL:   func.func @minmax_ugt(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xi32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : i32) outs(%[[EMPTY_0]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<i32>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_0]] : i32) outs(%[[EMPTY_1]] : tensor<i32>) -> tensor<i32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FILL_0]] : tensor<4096xi32>) outs(%[[FILL_1]] : tensor<i32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) {
+// CHECK:               %[[MAXUI_0:.*]] = arith.maxui %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:               linalg.yield %[[MAXUI_0]] : i32
 // CHECK:             }
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[REDUCE_0]][] : tensor<i32>
+// CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
+// CHECK:           affine.store %[[EXTRACT_0]], %[[REINTERPRET_CAST_0]][0] : memref<1xi32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }
 
 // -----
 
@@ -76,20 +95,30 @@ module {
   }
 }
 
-// CHECK-LABEL:  func.func @minmax_slt
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_2147483647_:%.+]] = arith.constant 2147483647 : i32
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_2147483647_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
-// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
-// CHECK:               [[VAR_3_:%.+]] = arith.minsi [[in_]], [[init_]] : i32
-// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK-LABEL:   func.func @minmax_slt(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xi32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 2147483647 : i32
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : i32) outs(%[[EMPTY_0]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<i32>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_1]] : i32) outs(%[[EMPTY_1]] : tensor<i32>) -> tensor<i32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FILL_0]] : tensor<4096xi32>) outs(%[[FILL_1]] : tensor<i32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) {
+// CHECK:               %[[MINSI_0:.*]] = arith.minsi %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:               linalg.yield %[[MINSI_0]] : i32
 // CHECK:             }
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[REDUCE_0]][] : tensor<i32>
+// CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
+// CHECK:           affine.store %[[EXTRACT_0]], %[[REINTERPRET_CAST_0]][0] : memref<1xi32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }
 
 
 // -----
@@ -108,17 +137,27 @@ module {
   }
 }
 
-// CHECK-LABEL:  func.func @minmax_ult
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xi32>, [[PARAM_1_:%.+]]: i32, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_minus_1_:%.+]] = arith.constant -1 : i32
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_minus_1_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
-// CHECK:             ([[in_:%.+]]: i32, [[init_:%.+]]: i32) {
-// CHECK:               [[VAR_3_:%.+]] = arith.minui [[in_]], [[init_]] : i32
-// CHECK:               linalg.yield [[VAR_3_]] : i32
+// CHECK-LABEL:   func.func @minmax_ult(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xi32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant -1 : i32
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : i32) outs(%[[EMPTY_0]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<i32>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_1]] : i32) outs(%[[EMPTY_1]] : tensor<i32>) -> tensor<i32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FILL_0]] : tensor<4096xi32>) outs(%[[FILL_1]] : tensor<i32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) {
+// CHECK:               %[[MINUI_0:.*]] = arith.minui %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:               linalg.yield %[[MINUI_0]] : i32
 // CHECK:             }
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[REDUCE_0]][] : tensor<i32>
+// CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [1], strides: [1] : memref<*xi32> to memref<1xi32, strided<[1]>>
+// CHECK:           affine.store %[[EXTRACT_0]], %[[REINTERPRET_CAST_0]][0] : memref<1xi32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/cumsum.mlir
+++ b/test/Conversion/StructuredToMemref/cumsum.mlir
@@ -40,6 +40,9 @@
 // CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:      %[[ARG8:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : index
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 4096 : index
 // CHECK:           %[[MULI_0:.*]] = arith.muli %[[ARG6]], %[[ARG2]] : i32
 // CHECK:           %[[INDEX_CAST_0:.*]] = arith.index_cast %[[MULI_0]] : i32 to index
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: {{\[}}%[[INDEX_CAST_0]]], sizes: [4096], strides: [1] : memref<*xf32> to memref<4096xf32, strided<[1], offset: ?>>
@@ -47,11 +50,18 @@
 // CHECK:           memref.copy %[[REINTERPRET_CAST_0]], %[[ALLOC_0]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<4096xf32> to tensor<4096xf32>
 // CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xf32>
-// CHECK:           %[[CUMSUM_0:.*]] = ttx.cumsum {axis = 0 : ui32, operandSegmentSizes = array<i32: 1, 1>} ins(%[[TO_TENSOR_0]] : tensor<4096xf32>) outs(%[[EMPTY_0]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[TO_TENSOR_0]]{{\[}}%[[CONSTANT_0]]] : tensor<4096xf32>
+// CHECK:           %[[INSERT_0:.*]] = tensor.insert %[[EXTRACT_0]] into %[[EMPTY_0]]{{\[}}%[[CONSTANT_0]]] : tensor<4096xf32>
+// CHECK:           %[[FOR_0:.*]]:2 = scf.for %[[VAL_0:.*]] = %[[CONSTANT_1]] to %[[CONSTANT_2]] step %[[CONSTANT_1]] iter_args(%[[VAL_1:.*]] = %[[EXTRACT_0]], %[[VAL_2:.*]] = %[[INSERT_0]]) -> (f32, tensor<4096xf32>) {
+// CHECK:             %[[EXTRACT_1:.*]] = tensor.extract %[[TO_TENSOR_0]]{{\[}}%[[VAL_0]]] : tensor<4096xf32>
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[VAL_1]], %[[EXTRACT_1]] : f32
+// CHECK:             %[[INSERT_1:.*]] = tensor.insert %[[ADDF_0]] into %[[VAL_2]]{{\[}}%[[VAL_0]]] : tensor<4096xf32>
+// CHECK:             scf.yield %[[ADDF_0]], %[[INSERT_1]] : f32, tensor<4096xf32>
+// CHECK:           }
 // CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<4096xi32>
-// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[CUMSUM_0]] : tensor<4096xf32>) outs(%[[EMPTY_1]] : tensor<4096xi32>) {
-// CHECK:           ^bb0(%[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: i32):
-// CHECK:             %[[FPTOSI_0:.*]] = arith.fptosi %[[VAL_0]] : f32 to i32
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[VAL_3:.*]]#1 : tensor<4096xf32>) outs(%[[EMPTY_1]] : tensor<4096xi32>) {
+// CHECK:           ^bb0(%[[VAL_4:.*]]: f32, %[[VAL_5:.*]]: i32):
+// CHECK:             %[[FPTOSI_0:.*]] = arith.fptosi %[[VAL_4]] : f32 to i32
 // CHECK:             linalg.yield %[[FPTOSI_0]] : i32
 // CHECK:           } -> tensor<4096xi32>
 // CHECK:           %[[REINTERPRET_CAST_1:.*]] = memref.reinterpret_cast %[[ARG1]] to offset: {{\[}}%[[INDEX_CAST_0]]], sizes: [4096], strides: [1] : memref<*xi32> to memref<4096xi32, strided<[1], offset: ?>>

--- a/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-02-fused-softmax.mlir
@@ -42,17 +42,17 @@
 // CHECK:           %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_0]][0] {{\[}}%[[MAXSI_0]]] [1] : memref<128xf32> to memref<?xf32, strided<[1]>>
 // CHECK:           memref.copy %[[SUBVIEW_0]], %[[SUBVIEW_1]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<128xf32> to tensor<128xf32>
-// CHECK:           %[[ALLOC_TENSOR_0:.*]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           %[[INSERT_0:.*]] = tensor.insert %[[CONSTANT_2]] into %[[ALLOC_TENSOR_0]][] : tensor<f32>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<128xf32>) outs(%[[INSERT_0]] : tensor<f32>) dimensions = [0]
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<f32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_2]] : f32) outs(%[[EMPTY_0]] : tensor<f32>) -> tensor<f32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<128xf32>) outs(%[[FILL_0]] : tensor<f32>) dimensions = [0]
 // CHECK:             (%[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32) {
 // CHECK:               %[[MAXIMUMF_0:.*]] = arith.maximumf %[[VAL_0]], %[[VAL_1]] : f32
 // CHECK:               linalg.yield %[[MAXIMUMF_0]] : f32
 // CHECK:             }
 // CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[REDUCE_0]][] : tensor<f32>
-// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<128xf32>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[EXTRACT_0]] : f32) outs(%[[EMPTY_0]] : tensor<128xf32>) -> tensor<128xf32>
-// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[TO_TENSOR_0]], %[[FILL_0]] : tensor<128xf32>, tensor<128xf32>) outs(%[[TO_TENSOR_0]] : tensor<128xf32>) {
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<128xf32>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[EXTRACT_0]] : f32) outs(%[[EMPTY_1]] : tensor<128xf32>) -> tensor<128xf32>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[TO_TENSOR_0]], %[[FILL_1]] : tensor<128xf32>, tensor<128xf32>) outs(%[[TO_TENSOR_0]] : tensor<128xf32>) {
 // CHECK:           ^bb0(%[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: f32, %[[VAL_4:.*]]: f32):
 // CHECK:             %[[SUBF_0:.*]] = arith.subf %[[VAL_2]], %[[VAL_3]] : f32
 // CHECK:             linalg.yield %[[SUBF_0]] : f32
@@ -62,16 +62,15 @@
 // CHECK:             %[[EXP_0:.*]] = math.exp %[[VAL_5]] : f32
 // CHECK:             linalg.yield %[[EXP_0]] : f32
 // CHECK:           } -> tensor<128xf32>
-// CHECK:           %[[ALLOC_TENSOR_1:.*]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           %[[INSERT_1:.*]] = tensor.insert %[[CONSTANT_3]] into %[[ALLOC_TENSOR_1]][] : tensor<f32>
-// CHECK:           %[[REDUCE_1:.*]] = linalg.reduce ins(%[[GENERIC_1]] : tensor<128xf32>) outs(%[[INSERT_1]] : tensor<f32>) dimensions = [0]
+// CHECK:           %[[FILL_2:.*]] = linalg.fill ins(%[[CONSTANT_3]] : f32) outs(%[[EMPTY_0]] : tensor<f32>) -> tensor<f32>
+// CHECK:           %[[REDUCE_1:.*]] = linalg.reduce ins(%[[GENERIC_1]] : tensor<128xf32>) outs(%[[FILL_2]] : tensor<f32>) dimensions = [0]
 // CHECK:             (%[[VAL_7:.*]]: f32, %[[VAL_8:.*]]: f32) {
 // CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_7]], %[[VAL_8]] : f32
 // CHECK:               linalg.yield %[[ADDF_0]] : f32
 // CHECK:             }
 // CHECK:           %[[EXTRACT_1:.*]] = tensor.extract %[[REDUCE_1]][] : tensor<f32>
-// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[EXTRACT_1]] : f32) outs(%[[EMPTY_0]] : tensor<128xf32>) -> tensor<128xf32>
-// CHECK:           %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[GENERIC_1]], %[[FILL_1]] : tensor<128xf32>, tensor<128xf32>) outs(%[[GENERIC_1]] : tensor<128xf32>) {
+// CHECK:           %[[FILL_3:.*]] = linalg.fill ins(%[[EXTRACT_1]] : f32) outs(%[[EMPTY_1]] : tensor<128xf32>) -> tensor<128xf32>
+// CHECK:           %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[GENERIC_1]], %[[FILL_3]] : tensor<128xf32>, tensor<128xf32>) outs(%[[GENERIC_1]] : tensor<128xf32>) {
 // CHECK:           ^bb0(%[[VAL_9:.*]]: f32, %[[VAL_10:.*]]: f32, %[[VAL_11:.*]]: f32):
 // CHECK:             %[[DIVF_0:.*]] = arith.divf %[[VAL_9]], %[[VAL_10]] : f32
 // CHECK:             linalg.yield %[[DIVF_0]] : f32

--- a/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-03-matrix-multiplication.mlir
@@ -84,20 +84,37 @@
 // CHECK:             %[[ALLOC_1:.*]] = memref.alloc() : memref<64x256xbf16>
 // CHECK:             memref.copy %[[REINTERPRET_CAST_1]], %[[ALLOC_1]] : memref<64x256xbf16, strided<[?, ?], offset: ?>> to memref<64x256xbf16>
 // CHECK:             %[[TO_TENSOR_1:.*]] = bufferization.to_tensor %[[ALLOC_1]] restrict writable : memref<64x256xbf16> to tensor<64x256xbf16>
-// CHECK:             %[[MATMUL_0:.*]] = linalg.matmul ins(%[[TO_TENSOR_0]], %[[TO_TENSOR_1]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs(%[[FILL_0]] : tensor<128x256xf32>) -> tensor<128x256xf32>
-// CHECK:             %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_1]], %[[MATMUL_0]] : tensor<128x256xf32>, tensor<128x256xf32>) outs(%[[VAL_1]] : tensor<128x256xf32>) {
-// CHECK:             ^bb0(%[[VAL_4:.*]]: f32, %[[VAL_5:.*]]: f32, %[[VAL_6:.*]]: f32):
-// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_4]], %[[VAL_5]] : f32
+// CHECK:             %[[EMPTY_1:.*]] = tensor.empty() : tensor<128x64xf32>
+// CHECK:             %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel", "parallel"]} ins(%[[TO_TENSOR_0]] : tensor<128x64xbf16>) outs(%[[EMPTY_1]] : tensor<128x64xf32>) {
+// CHECK:             ^bb0(%[[VAL_4:.*]]: bf16, %[[VAL_5:.*]]: f32):
+// CHECK:               %[[EXTF_0:.*]] = arith.extf %[[VAL_4]] : bf16 to f32
+// CHECK:               linalg.yield %[[EXTF_0]] : f32
+// CHECK:             } -> tensor<128x64xf32>
+// CHECK:             %[[EMPTY_2:.*]] = tensor.empty() : tensor<64x256xf32>
+// CHECK:             %[[GENERIC_1:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel", "parallel"]} ins(%[[TO_TENSOR_1]] : tensor<64x256xbf16>) outs(%[[EMPTY_2]] : tensor<64x256xf32>) {
+// CHECK:             ^bb0(%[[VAL_6:.*]]: bf16, %[[VAL_7:.*]]: f32):
+// CHECK:               %[[EXTF_1:.*]] = arith.extf %[[VAL_6]] : bf16 to f32
+// CHECK:               linalg.yield %[[EXTF_1]] : f32
+// CHECK:             } -> tensor<64x256xf32>
+// CHECK:             %[[MATMUL_0:.*]] = linalg.matmul ins(%[[GENERIC_0]], %[[GENERIC_1]] : tensor<128x64xf32>, tensor<64x256xf32>) outs(%[[FILL_0]] : tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:             %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel", "parallel"]} ins(%[[FILL_0]], %[[MATMUL_0]] : tensor<128x256xf32>, tensor<128x256xf32>) outs(%[[FILL_0]] : tensor<128x256xf32>) {
+// CHECK:             ^bb0(%[[VAL_8:.*]]: f32, %[[VAL_9:.*]]: f32, %[[VAL_10:.*]]: f32):
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_8]], %[[VAL_9]] : f32
 // CHECK:               linalg.yield %[[ADDF_0]] : f32
+// CHECK:             } -> tensor<128x256xf32>
+// CHECK:             %[[GENERIC_3:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_1]], %[[GENERIC_2]] : tensor<128x256xf32>, tensor<128x256xf32>) outs(%[[VAL_1]] : tensor<128x256xf32>) {
+// CHECK:             ^bb0(%[[VAL_11:.*]]: f32, %[[VAL_12:.*]]: f32, %[[VAL_13:.*]]: f32):
+// CHECK:               %[[ADDF_1:.*]] = arith.addf %[[VAL_11]], %[[VAL_12]] : f32
+// CHECK:               linalg.yield %[[ADDF_1]] : f32
 // CHECK:             } -> tensor<128x256xf32>
 // CHECK:             %[[ADDI_5:.*]] = arith.addi %[[VAL_2]], %[[INDEX_CAST_6]] : index
 // CHECK:             %[[ADDI_6:.*]] = arith.addi %[[VAL_3]], %[[INDEX_CAST_7]] : index
-// CHECK:             scf.yield %[[GENERIC_0]], %[[ADDI_5]], %[[ADDI_6]] : tensor<128x256xf32>, index, index
+// CHECK:             scf.yield %[[GENERIC_3]], %[[ADDI_5]], %[[ADDI_6]] : tensor<128x256xf32>, index, index
 // CHECK:           }
-// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<128x256xbf16>
-// CHECK:           %[[GENERIC_1:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_7:.*]]#0 : tensor<128x256xf32>) outs(%[[EMPTY_1]] : tensor<128x256xbf16>) {
-// CHECK:           ^bb0(%[[VAL_8:.*]]: f32, %[[VAL_9:.*]]: bf16):
-// CHECK:             %[[TRUNCF_0:.*]] = arith.truncf %[[VAL_8]] : f32 to bf16
+// CHECK:           %[[EMPTY_3:.*]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           %[[GENERIC_4:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_14:.*]]#0 : tensor<128x256xf32>) outs(%[[EMPTY_3]] : tensor<128x256xbf16>) {
+// CHECK:           ^bb0(%[[VAL_15:.*]]: f32, %[[VAL_16:.*]]: bf16):
+// CHECK:             %[[TRUNCF_0:.*]] = arith.truncf %[[VAL_15]] : f32 to bf16
 // CHECK:             linalg.yield %[[TRUNCF_0]] : bf16
 // CHECK:           } -> tensor<128x256xbf16>
 // CHECK:           %[[INDEX_CAST_8:.*]] = arith.index_cast %[[ARG10]] : i32 to index
@@ -118,7 +135,7 @@
 // CHECK:           %[[MINSI_4:.*]] = arith.minsi %[[SUBI_2]], %[[CONSTANT_3]] : index
 // CHECK:           %[[ADDI_9:.*]] = arith.addi %[[MULI_8]], %[[MULI_9]] : index
 // CHECK:           %[[REINTERPRET_CAST_2:.*]] = memref.reinterpret_cast %[[ARG2]] to offset: {{\[}}%[[ADDI_9]]], sizes: [128, 256], strides: {{\[}}%[[INDEX_CAST_8]], %[[INDEX_CAST_9]]] : memref<*xbf16> to memref<128x256xbf16, strided<[?, ?], offset: ?>>
-// CHECK:           %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[GENERIC_1]][0, 0] {{\[}}%[[MINSI_3]], %[[MINSI_4]]] [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
+// CHECK:           %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[GENERIC_4]][0, 0] {{\[}}%[[MINSI_3]], %[[MINSI_4]]] [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
 // CHECK:           %[[SUBVIEW_0:.*]] = memref.subview %[[REINTERPRET_CAST_2]][0, 0] {{\[}}%[[MINSI_3]], %[[MINSI_4]]] [1, 1] : memref<128x256xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[?, ?], offset: ?>>
 // CHECK:           bufferization.materialize_in_destination %[[EXTRACT_SLICE_0]] in writable %[[SUBVIEW_0]] : (tensor<?x?xbf16>, memref<?x?xbf16, strided<[?, ?], offset: ?>>) -> ()
 // CHECK:           return

--- a/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/StructuredToMemref/kernel-05-layer-norm-fwd.mlir
@@ -69,9 +69,9 @@
 // CHECK:             } -> tensor<256xf32>
 // CHECK:             scf.yield %[[GENERIC_1]] : tensor<256xf32>
 // CHECK:           }
-// CHECK:           %[[ALLOC_TENSOR_0:.*]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           %[[INSERT_0:.*]] = tensor.insert %[[CONSTANT_1]] into %[[ALLOC_TENSOR_0]][] : tensor<f32>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FOR_0]] : tensor<256xf32>) outs(%[[INSERT_0]] : tensor<f32>) dimensions = [0]
+// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<f32>
+// CHECK:           %[[FILL_2:.*]] = linalg.fill ins(%[[CONSTANT_1]] : f32) outs(%[[EMPTY_2]] : tensor<f32>) -> tensor<f32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[FOR_0]] : tensor<256xf32>) outs(%[[FILL_2]] : tensor<f32>) dimensions = [0]
 // CHECK:             (%[[VAL_6:.*]]: f32, %[[VAL_7:.*]]: f32) {
 // CHECK:               %[[ADDF_1:.*]] = arith.addf %[[VAL_6]], %[[VAL_7]] : f32
 // CHECK:               linalg.yield %[[ADDF_1]] : f32
@@ -79,16 +79,16 @@
 // CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[REDUCE_0]][] : tensor<f32>
 // CHECK:           %[[SITOFP_0:.*]] = arith.sitofp %[[ARG7]] : i32 to f32
 // CHECK:           %[[DIVF_0:.*]] = arith.divf %[[EXTRACT_0]], %[[SITOFP_0]] : f32
-// CHECK:           %[[FILL_2:.*]] = linalg.fill ins(%[[DIVF_0]] : f32) outs(%[[EMPTY_0]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           %[[FILL_3:.*]] = linalg.fill ins(%[[DIVF_0]] : f32) outs(%[[EMPTY_0]] : tensor<256xf32>) -> tensor<256xf32>
 // CHECK:           %[[FOR_1:.*]] = scf.for %[[VAL_8:.*]] = %[[CONSTANT_2]] to %[[ARG7]] step %[[CONSTANT_3]] iter_args(%[[VAL_9:.*]] = %[[FILL_0]]) -> (tensor<256xf32>)  : i32 {
-// CHECK:             %[[FILL_3:.*]] = linalg.fill ins(%[[VAL_8]] : i32) outs(%[[EMPTY_1]] : tensor<256xi32>) -> tensor<256xi32>
-// CHECK:             %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[FILL_3]], %[[GENERIC_0]] : tensor<256xi32>, tensor<256xi32>) outs(%[[FILL_3]] : tensor<256xi32>) {
+// CHECK:             %[[FILL_4:.*]] = linalg.fill ins(%[[VAL_8]] : i32) outs(%[[EMPTY_1]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK:             %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[FILL_4]], %[[GENERIC_0]] : tensor<256xi32>, tensor<256xi32>) outs(%[[FILL_4]] : tensor<256xi32>) {
 // CHECK:             ^bb0(%[[VAL_10:.*]]: i32, %[[VAL_11:.*]]: i32, %[[VAL_12:.*]]: i32):
 // CHECK:               %[[ADDI_2:.*]] = arith.addi %[[VAL_10]], %[[VAL_11]] : i32
 // CHECK:               linalg.yield %[[ADDI_2]] : i32
 // CHECK:             } -> tensor<256xi32>
-// CHECK:             %[[EMPTY_2:.*]] = tensor.empty() : tensor<256xi1>
-// CHECK:             %[[GENERIC_3:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[GENERIC_2]], %[[FILL_1]] : tensor<256xi32>, tensor<256xi32>) outs(%[[EMPTY_2]] : tensor<256xi1>) {
+// CHECK:             %[[EMPTY_3:.*]] = tensor.empty() : tensor<256xi1>
+// CHECK:             %[[GENERIC_3:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[GENERIC_2]], %[[FILL_1]] : tensor<256xi32>, tensor<256xi32>) outs(%[[EMPTY_3]] : tensor<256xi1>) {
 // CHECK:             ^bb0(%[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i32, %[[VAL_15:.*]]: i1):
 // CHECK:               %[[CMPI_1:.*]] = arith.cmpi slt, %[[VAL_13]], %[[VAL_14]] : i32
 // CHECK:               linalg.yield %[[CMPI_1]] : i1
@@ -110,7 +110,7 @@
 // CHECK:             %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_1]][0] {{\[}}%[[SUBI_1]]] [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
 // CHECK:             memref.copy %[[SUBVIEW_2]], %[[SUBVIEW_3]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
 // CHECK:             %[[TO_TENSOR_1:.*]] = bufferization.to_tensor %[[ALLOC_1]] restrict writable : memref<256xf32> to tensor<256xf32>
-// CHECK:             %[[GENERIC_4:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[TO_TENSOR_1]], %[[FILL_2]] : tensor<256xf32>, tensor<256xf32>) outs(%[[TO_TENSOR_1]] : tensor<256xf32>) {
+// CHECK:             %[[GENERIC_4:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[TO_TENSOR_1]], %[[FILL_3]] : tensor<256xf32>, tensor<256xf32>) outs(%[[TO_TENSOR_1]] : tensor<256xf32>) {
 // CHECK:             ^bb0(%[[VAL_16:.*]]: f32, %[[VAL_17:.*]]: f32, %[[VAL_18:.*]]: f32):
 // CHECK:               %[[SUBF_0:.*]] = arith.subf %[[VAL_16]], %[[VAL_17]] : f32
 // CHECK:               linalg.yield %[[SUBF_0]] : f32
@@ -132,9 +132,7 @@
 // CHECK:             } -> tensor<256xf32>
 // CHECK:             scf.yield %[[GENERIC_7]] : tensor<256xf32>
 // CHECK:           }
-// CHECK:           %[[ALLOC_TENSOR_1:.*]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           %[[INSERT_1:.*]] = tensor.insert %[[CONSTANT_1]] into %[[ALLOC_TENSOR_1]][] : tensor<f32>
-// CHECK:           %[[REDUCE_1:.*]] = linalg.reduce ins(%[[FOR_1]] : tensor<256xf32>) outs(%[[INSERT_1]] : tensor<f32>) dimensions = [0]
+// CHECK:           %[[REDUCE_1:.*]] = linalg.reduce ins(%[[FOR_1]] : tensor<256xf32>) outs(%[[FILL_2]] : tensor<f32>) dimensions = [0]
 // CHECK:             (%[[VAL_29:.*]]: f32, %[[VAL_30:.*]]: f32) {
 // CHECK:               %[[ADDF_3:.*]] = arith.addf %[[VAL_29]], %[[VAL_30]] : f32
 // CHECK:               linalg.yield %[[ADDF_3]] : f32
@@ -149,7 +147,7 @@
 // CHECK:           affine.store %[[DIVF_0]], %[[REINTERPRET_CAST_2]][0] : memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           %[[REINTERPRET_CAST_3:.*]] = memref.reinterpret_cast %[[ARG5]] to offset: {{\[}}%[[INDEX_CAST_6]]], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
 // CHECK:           affine.store %[[DIVF_2]], %[[REINTERPRET_CAST_3]][0] : memref<1xf32, strided<[1], offset: ?>>
-// CHECK:           %[[FILL_4:.*]] = linalg.fill ins(%[[DIVF_2]] : f32) outs(%[[EMPTY_0]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           %[[FILL_5:.*]] = linalg.fill ins(%[[DIVF_2]] : f32) outs(%[[EMPTY_0]] : tensor<256xf32>) -> tensor<256xf32>
 // CHECK:           scf.for %[[VAL_31:.*]] = %[[CONSTANT_2]] to %[[ARG7]] step %[[CONSTANT_3]]  : i32 {
 // CHECK:             %[[INDEX_CAST_7:.*]] = arith.index_cast %[[VAL_31]] : i32 to index
 // CHECK:             %[[ADDI_5:.*]] = arith.addi %[[INDEX_CAST_7]], %[[CONSTANT_0]] : index
@@ -180,12 +178,12 @@
 // CHECK:             %[[SUBVIEW_9:.*]] = memref.subview %[[ALLOC_4]][0] {{\[}}%[[SUBI_2]]] [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
 // CHECK:             memref.copy %[[SUBVIEW_8]], %[[SUBVIEW_9]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
 // CHECK:             %[[TO_TENSOR_4:.*]] = bufferization.to_tensor %[[ALLOC_4]] restrict writable : memref<256xf32> to tensor<256xf32>
-// CHECK:             %[[GENERIC_8:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[TO_TENSOR_4]], %[[FILL_2]] : tensor<256xf32>, tensor<256xf32>) outs(%[[TO_TENSOR_4]] : tensor<256xf32>) {
+// CHECK:             %[[GENERIC_8:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[TO_TENSOR_4]], %[[FILL_3]] : tensor<256xf32>, tensor<256xf32>) outs(%[[TO_TENSOR_4]] : tensor<256xf32>) {
 // CHECK:             ^bb0(%[[VAL_32:.*]]: f32, %[[VAL_33:.*]]: f32, %[[VAL_34:.*]]: f32):
 // CHECK:               %[[SUBF_1:.*]] = arith.subf %[[VAL_32]], %[[VAL_33]] : f32
 // CHECK:               linalg.yield %[[SUBF_1]] : f32
 // CHECK:             } -> tensor<256xf32>
-// CHECK:             %[[GENERIC_9:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[GENERIC_8]], %[[FILL_4]] : tensor<256xf32>, tensor<256xf32>) outs(%[[GENERIC_8]] : tensor<256xf32>) {
+// CHECK:             %[[GENERIC_9:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[GENERIC_8]], %[[FILL_5]] : tensor<256xf32>, tensor<256xf32>) outs(%[[GENERIC_8]] : tensor<256xf32>) {
 // CHECK:             ^bb0(%[[VAL_35:.*]]: f32, %[[VAL_36:.*]]: f32, %[[VAL_37:.*]]: f32):
 // CHECK:               %[[MULF_1:.*]] = arith.mulf %[[VAL_35]], %[[VAL_36]] : f32
 // CHECK:               linalg.yield %[[MULF_1]] : f32

--- a/test/Conversion/StructuredToMemref/masked_reduce_rank1.mlir
+++ b/test/Conversion/StructuredToMemref/masked_reduce_rank1.mlir
@@ -28,7 +28,6 @@
 // CHECK:           %[[INDEX_CAST_0:.*]] = arith.index_cast %[[ARG2]] : i32 to index
 // CHECK:           %[[MINSI_0:.*]] = arith.minsi %[[INDEX_CAST_0]], %[[CONSTANT_0]] : index
 // CHECK:           %[[MAXSI_0:.*]] = arith.maxsi %[[MINSI_0]], %[[CONSTANT_1]] : index
-// CHECK:           %[[ALLOC_TENSOR_0:.*]] = bufferization.alloc_tensor() : tensor<f32>
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [128], strides: [1] : memref<*xf32> to memref<128xf32, strided<[1]>>
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[MAXSI_0]], %[[CONSTANT_4]] : index
 // CHECK:           %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_4]] : index
@@ -91,7 +90,6 @@ module {
 // CHECK:           %[[INDEX_CAST_0:.*]] = arith.index_cast %[[ARG2]] : i32 to index
 // CHECK:           %[[MINSI_0:.*]] = arith.minsi %[[INDEX_CAST_0]], %[[CONSTANT_0]] : index
 // CHECK:           %[[MAXSI_0:.*]] = arith.maxsi %[[MINSI_0]], %[[CONSTANT_1]] : index
-// CHECK:           %[[ALLOC_TENSOR_0:.*]] = bufferization.alloc_tensor() : tensor<f32>
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [128], strides: [1] : memref<*xf32> to memref<128xf32, strided<[1]>>
 // CHECK:           %[[DIVUI_0:.*]] = arith.divui %[[MAXSI_0]], %[[CONSTANT_4]] : index
 // CHECK:           %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_4]] : index
@@ -173,9 +171,9 @@ module {
 // CHECK:             memref.store %[[LOAD_1]], %[[SUBVIEW_1]]{{\[}}%[[VAL_1]]] : memref<?xf32, strided<[1]>>
 // CHECK:           }
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<128xf32> to tensor<128xf32>
-// CHECK:           %[[ALLOC_TENSOR_0:.*]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           %[[INSERT_0:.*]] = tensor.insert %[[CONSTANT_4]] into %[[ALLOC_TENSOR_0]][] : tensor<f32>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<128xf32>) outs(%[[INSERT_0]] : tensor<f32>) dimensions = [0]
+// CHECK:           %[[REDUCE_EMPTY_0:.*]] = tensor.empty() : tensor<f32>
+// CHECK:           %[[REDUCE_INIT_0:.*]] = linalg.fill ins(%[[CONSTANT_4]] : f32) outs(%[[REDUCE_EMPTY_0]] : tensor<f32>) -> tensor<f32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<128xf32>) outs(%[[REDUCE_INIT_0]] : tensor<f32>) dimensions = [0]
 // CHECK:             (%[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: f32) {
 // CHECK:               %[[MULF_0:.*]] = arith.mulf %[[VAL_2]], %[[VAL_3]] : f32
 // CHECK:               linalg.yield %[[MULF_0]] : f32

--- a/test/Conversion/StructuredToMemref/reducemax_32_256_bf16.mlir
+++ b/test/Conversion/StructuredToMemref/reducemax_32_256_bf16.mlir
@@ -41,31 +41,7 @@ module {
     }
 }
 
-// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
-// CHECK-LABEL:  func.func @kernel
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_empty_offsets_:%.+]] = tensor.empty() : tensor<256x16xi32>
-// CHECK-DAG:       [[VAR_zero_offsets_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_empty_offsets_]] : tensor<256x16xi32>) -> tensor<256x16xi32>
-// CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0xFF80 : bf16
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [32, 256, 16], strides: [256, 1, 1] : memref<*xbf16> to memref<32x256x16xbf16, strided<[256, 1, 1]>>
-// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32x256x16xbf16>
-// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<32x256x16xbf16, strided<[256, 1, 1]>> to memref<32x256x16xbf16>
-// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32x256x16xbf16>
-// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<256x16xbf16>
-// CHECK:           [[VAR_2_:%.+]] = linalg.fill ins([[CST_0_1_]] : bf16) outs([[VAR_1_]] : tensor<256x16xbf16>) -> tensor<256x16xbf16>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_0_]] : tensor<32x256x16xbf16>) outs([[VAR_2_]] : tensor<256x16xbf16>) dimensions = [0]
-// CHECK:             ([[in_:.+]]: bf16, [[init_:.+]]: bf16) {
-// CHECK:               [[VAR_3_:%.+]] = arith.maximumf [[in_]], [[init_]] : bf16
-// CHECK:               linalg.yield [[VAR_3_]] : bf16
-// CHECK:             }
-// CHECK:           [[VAR_cast_:%.+]] = memref.cast [[PARAM_1_]] : memref<*xbf16> to memref<?xbf16>
-// CHECK:           linalg.generic {indexing_maps = [[[MAP_0_]], [[MAP_0_]]], iterator_types = ["parallel", "parallel"]} ins([[VAR_zero_offsets_]], [[VAR_reduced_]] : tensor<256x16xi32>, tensor<256x16xbf16>) {
-// CHECK:           ^bb0([[IN_0_:%.+]]: i32, [[IN_1_:%.+]]: bf16):
-// CHECK:             [[VAR_4_:%.+]] = arith.index_cast [[IN_0_]] : i32 to index
-// CHECK:             memref.store [[IN_1_]], [[VAR_cast_]]{{.}}[[VAR_4_]]{{.}} : memref<?xbf16>
-// CHECK:             linalg.yield
-// CHECK:           }
-// CHECK:           return
-// CHECK:         }
+// CHECK-LABEL: func.func @kernel
+// CHECK: linalg.reduce
+// CHECK: memref.store
+// CHECK: return

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis0.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis0.mlir
@@ -9,6 +9,7 @@
 
 
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:   func.func @kernel(
 // CHECK-SAME:                      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xbf16>,
 // CHECK-SAME:                      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xbf16>,
@@ -18,20 +19,27 @@
 // CHECK-SAME:                      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [512, 256], strides: [256, 1] : memref<*xbf16> to memref<512x256xbf16, strided<[256, 1]>>
 // CHECK:           %[[ALLOC_0:.*]] = memref.alloc() : memref<512x256xbf16>
 // CHECK:           memref.copy %[[REINTERPRET_CAST_0]], %[[ALLOC_0]] : memref<512x256xbf16, strided<[256, 1]>> to memref<512x256xbf16>
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<512x256xbf16> to tensor<512x256xbf16>
-// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256xbf16>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : bf16) outs(%[[EMPTY_0]] : tensor<256xbf16>) -> tensor<256xbf16>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<512x256xbf16>) outs(%[[FILL_0]] : tensor<256xbf16>) dimensions = [0]
-// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: bf16) {
-// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : bf16
-// CHECK:               linalg.yield %[[ADDF_0]] : bf16
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_0]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<512x256xbf16>) outs(%[[FILL_0]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: f32) {
+// CHECK:               %[[EXTF_0:.*]] = arith.extf %[[VAL_0]] : bf16 to f32
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[EXTF_0]], %[[VAL_1]] : f32
+// CHECK:               linalg.yield %[[ADDF_0]] : f32
 // CHECK:             }
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<256xbf16>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[REDUCE_0]] : tensor<256xf32>) outs(%[[EMPTY_1]] : tensor<256xbf16>) {
+// CHECK:           ^bb0(%[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: bf16):
+// CHECK:             %[[TRUNCF_0:.*]] = arith.truncf %[[VAL_2]] : f32 to bf16
+// CHECK:             linalg.yield %[[TRUNCF_0]] : bf16
+// CHECK:           } -> tensor<256xbf16>
 // CHECK:           %[[REINTERPRET_CAST_1:.*]] = memref.reinterpret_cast %[[ARG1]] to offset: [0], sizes: [256], strides: [1] : memref<*xbf16> to memref<256xbf16, strided<[1]>>
-// CHECK:           bufferization.materialize_in_destination %[[REDUCE_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<256xbf16>, memref<256xbf16, strided<[1]>>) -> ()
+// CHECK:           bufferization.materialize_in_destination %[[GENERIC_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<256xbf16>, memref<256xbf16, strided<[1]>>) -> ()
 // CHECK:           return
 // CHECK:         }
 module {

--- a/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis1.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_512_256_bf16_axis1.mlir
@@ -9,6 +9,7 @@
 
 
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0)>
 // CHECK-LABEL:   func.func @kernel(
 // CHECK-SAME:                      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xbf16>,
 // CHECK-SAME:                      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xbf16>,
@@ -18,22 +19,29 @@
 // CHECK-SAME:                      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [512, 256], strides: [256, 1] : memref<*xbf16> to memref<512x256xbf16, strided<[256, 1]>>
 // CHECK:           %[[ALLOC_0:.*]] = memref.alloc() : memref<512x256xbf16>
 // CHECK:           memref.copy %[[REINTERPRET_CAST_0]], %[[ALLOC_0]] : memref<512x256xbf16, strided<[256, 1]>> to memref<512x256xbf16>
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<512x256xbf16> to tensor<512x256xbf16>
 // CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256x512xbf16>
 // CHECK:           %[[TRANSPOSE_0:.*]] = linalg.transpose ins(%[[TO_TENSOR_0]] : tensor<512x256xbf16>) outs(%[[EMPTY_0]] : tensor<256x512xbf16>) permutation = [1, 0]
-// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<512xbf16>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : bf16) outs(%[[EMPTY_1]] : tensor<512xbf16>) -> tensor<512xbf16>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TRANSPOSE_0]] : tensor<256x512xbf16>) outs(%[[FILL_0]] : tensor<512xbf16>) dimensions = [0]
-// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: bf16) {
-// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : bf16
-// CHECK:               linalg.yield %[[ADDF_0]] : bf16
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<512xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_1]] : tensor<512xf32>) -> tensor<512xf32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TRANSPOSE_0]] : tensor<256x512xbf16>) outs(%[[FILL_0]] : tensor<512xf32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: f32) {
+// CHECK:               %[[EXTF_0:.*]] = arith.extf %[[VAL_0]] : bf16 to f32
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[EXTF_0]], %[[VAL_1]] : f32
+// CHECK:               linalg.yield %[[ADDF_0]] : f32
 // CHECK:             }
+// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<512xbf16>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[REDUCE_0]] : tensor<512xf32>) outs(%[[EMPTY_2]] : tensor<512xbf16>) {
+// CHECK:           ^bb0(%[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: bf16):
+// CHECK:             %[[TRUNCF_0:.*]] = arith.truncf %[[VAL_2]] : f32 to bf16
+// CHECK:             linalg.yield %[[TRUNCF_0]] : bf16
+// CHECK:           } -> tensor<512xbf16>
 // CHECK:           %[[REINTERPRET_CAST_1:.*]] = memref.reinterpret_cast %[[ARG1]] to offset: [0], sizes: [512], strides: [1] : memref<*xbf16> to memref<512xbf16, strided<[1]>>
-// CHECK:           bufferization.materialize_in_destination %[[REDUCE_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<512xbf16>, memref<512xbf16, strided<[1]>>) -> ()
+// CHECK:           bufferization.materialize_in_destination %[[GENERIC_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<512xbf16>, memref<512xbf16, strided<[1]>>) -> ()
 // CHECK:           return
 // CHECK:         }
 module {

--- a/test/Conversion/StructuredToMemref/reducesum_middle_dim.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_middle_dim.mlir
@@ -41,33 +41,7 @@ module {
     }
 }
 
-// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
-// CHECK-LABEL:  func.func @kernel
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
-// CHECK-DAG:       [[VAR_empty_offsets_:%.+]] = tensor.empty() : tensor<32x16xi32>
-// CHECK-DAG:       [[VAR_zero_offsets_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_empty_offsets_]] : tensor<32x16xi32>) -> tensor<32x16xi32>
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: [0], sizes: [32, 256, 16], strides: [256, 1, 1] : memref<*xbf16> to memref<32x256x16xbf16, strided<[256, 1, 1]>>
-// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<32x256x16xbf16>
-// CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<32x256x16xbf16, strided<[256, 1, 1]>> to memref<32x256x16xbf16>
-// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<32x256x16xbf16>
-// CHECK:           [[VAL_7:%.+]] = tensor.empty() : tensor<256x32x16xbf16>
-// CHECK:           [[VAL_8:%.+]] = linalg.transpose ins([[VAR_0_]] : tensor<32x256x16xbf16>) outs([[VAL_7]] : tensor<256x32x16xbf16>) permutation = [1, 0, 2]
-// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<32x16xbf16>
-// CHECK:           [[VAR_2_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_1_]] : tensor<32x16xbf16>) -> tensor<32x16xbf16>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAL_8]] : tensor<256x32x16xbf16>) outs([[VAR_2_]] : tensor<32x16xbf16>) dimensions = [0]
-// CHECK:             ([[in_:.+]]: bf16, [[init_:.+]]: bf16) {
-// CHECK:               [[VAR_3_:%.+]] = arith.addf [[in_]], [[init_]] : bf16
-// CHECK:               linalg.yield [[VAR_3_]] : bf16
-// CHECK:             }
-// CHECK:           [[VAR_cast_:%.+]] = memref.cast [[PARAM_2_]] : memref<*xbf16> to memref<?xbf16>
-// CHECK:           linalg.generic {indexing_maps = [[[MAP_0_]], [[MAP_0_]]], iterator_types = ["parallel", "parallel"]} ins([[VAR_zero_offsets_]], [[VAR_reduced_]] : tensor<32x16xi32>, tensor<32x16xbf16>) {
-// CHECK:           ^bb0([[IN_0_:%.+]]: i32, [[IN_1_:%.+]]: bf16):
-// CHECK:             [[VAR_5_:%.+]] = arith.index_cast [[IN_0_]] : i32 to index
-// CHECK:             memref.store [[IN_1_]], [[VAR_cast_]]{{.}}[[VAR_5_]]{{.}} : memref<?xbf16>
-// CHECK:             linalg.yield
-// CHECK:           }
-// CHECK:           return
-// CHECK:         }
+// CHECK-LABEL: func.func @kernel
+// CHECK: linalg.reduce
+// CHECK: memref.store
+// CHECK: return

--- a/test/Conversion/StructuredToMemref/reducesum_scalar.mlir
+++ b/test/Conversion/StructuredToMemref/reducesum_scalar.mlir
@@ -16,16 +16,24 @@ module {
   }
 }
 
-// CHECK-LABEL:  func.func @kernel
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128xbf16>
-// CHECK-DAG:       [[VAR_0_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xbf16>
-// CHECK-DAG:       [[VAR_1_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_1_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_0_]] : tensor<128xbf16>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
-// CHECK:             ([[in_:%.+]]: bf16, [[init_:%.+]]: f32) {
-// CHECK:               [[VAR_3_:%.+]] = arith.extf [[in_]] : bf16 to f32
-// CHECK:               [[VAR_4_:%.+]] = arith.addf [[VAR_3_]], [[init_]] : f32
-// CHECK:               linalg.yield [[VAR_4_]] : f32
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:  %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32) {
+// CHECK:           %[[VAL_8:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<128xbf16>
+// CHECK:           memref.copy %[[VAL_9]], %[[VAL_10]] : memref<128xbf16, strided<[1]>> to memref<128xbf16>
+// CHECK:           %[[VAL_11:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<128xbf16> to tensor<128xbf16>
+// CHECK:           %[[VAL_12:.*]] = tensor.empty() : tensor<f32>
+// CHECK:           %[[VAL_13:.*]] = linalg.fill ins(%[[VAL_8]] : f32) outs(%[[VAL_12]] : tensor<f32>) -> tensor<f32>
+// CHECK:           %[[VAL_14:.*]] = linalg.reduce ins(%[[VAL_11]] : tensor<128xbf16>) outs(%[[VAL_13]] : tensor<f32>) dimensions = [0]
+// CHECK:             (%[[VAL_15:.*]]: bf16, %[[VAL_16:.*]]: f32) {
+// CHECK:               %[[VAL_17:.*]] = arith.extf %[[VAL_15]] : bf16 to f32
+// CHECK:               %[[VAL_18:.*]] = arith.addf %[[VAL_17]], %[[VAL_16]] : f32
+// CHECK:               linalg.yield %[[VAL_18]] : f32
 // CHECK:             }
+// CHECK:           %[[VAL_19:.*]] = tensor.extract %[[VAL_14]][] : tensor<f32>
+// CHECK:           %[[VAL_20:.*]] = arith.truncf %[[VAL_19]] : f32 to bf16
+// CHECK:           %[[VAL_21:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1]>>
+// CHECK:           affine.store %[[VAL_20]], %[[VAL_21]][0] : memref<1xbf16, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/StructuredToMemref/use_dot_opc.mlir
+++ b/test/Conversion/StructuredToMemref/use_dot_opc.mlir
@@ -9,6 +9,7 @@
 
 
 // RUN: triton-shared-opt --split-input-file --triton-to-linalg-experimental %s | FileCheck %s
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK-LABEL:   func.func @kernel(
 // CHECK-SAME:                      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xbf16>,
 // CHECK-SAME:                      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<*xbf16>,
@@ -31,8 +32,13 @@
 // CHECK:           memref.copy %[[REINTERPRET_CAST_1]], %[[ALLOC_1]] : memref<64x256xbf16, strided<[256, 1]>> to memref<64x256xbf16>
 // CHECK:           %[[TO_TENSOR_1:.*]] = bufferization.to_tensor %[[ALLOC_1]] restrict writable : memref<64x256xbf16> to tensor<64x256xbf16>
 // CHECK:           %[[MATMUL_0:.*]] = linalg.matmul ins(%[[TO_TENSOR_0]], %[[TO_TENSOR_1]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs(%[[FILL_0]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel", "parallel"]} ins(%[[FILL_0]], %[[MATMUL_0]] : tensor<128x256xbf16>, tensor<128x256xbf16>) outs(%[[FILL_0]] : tensor<128x256xbf16>) {
+// CHECK:           ^bb0(%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: bf16, %[[VAL_2:.*]]: bf16):
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : bf16
+// CHECK:             linalg.yield %[[ADDF_0]] : bf16
+// CHECK:           } -> tensor<128x256xbf16>
 // CHECK:           %[[REINTERPRET_CAST_2:.*]] = memref.reinterpret_cast %[[ARG2]] to offset: [0], sizes: [128, 256], strides: [256, 1] : memref<*xbf16> to memref<128x256xbf16, strided<[256, 1]>>
-// CHECK:           bufferization.materialize_in_destination %[[MATMUL_0]] in writable %[[REINTERPRET_CAST_2]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[256, 1]>>) -> ()
+// CHECK:           bufferization.materialize_in_destination %[[GENERIC_0]] in writable %[[REINTERPRET_CAST_2]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[256, 1]>>) -> ()
 // CHECK:           bufferization.materialize_in_destination %[[FILL_0]] in writable %[[REINTERPRET_CAST_2]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[256, 1]>>) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonArithToLinalg/convert_addi_reduce.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_addi_reduce.mlir
@@ -19,9 +19,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<i32>
+// CHECK:           [[VAR_init_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_2_]] : tensor<i32>) -> tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_init_]] : tensor<i32>) dimensions = [0]
 // CHECK:             ([[in_:%.+]]: i32, [[in_]]it: i32) {
 // CHECK:               [[VAR_3_:%.+]] = arith.addi [[in_]], [[in_]]it : i32
 // CHECK:               linalg.yield [[VAR_3_]] : i32

--- a/test/Conversion/TritonArithToLinalg/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_argmin_argmax_2d.mlir
@@ -126,74 +126,78 @@ module {
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<4x1xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_2_]] : tensor<4x1xi32>) -> tensor<4x1xi32>
 // CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]], [[VAR_3_]] : tensor<4x1xi32>, tensor<4x1xi32>) outs([[VAR_expanded_]] : tensor<4x1xi32>) {
-// CHECK:           ^bb0([[in_:%.+]]: i32, [[in_]]_1: i32, [[out_]]: i32):
-// CHECK:             [[VAR_28_1_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[in1_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             [[VAR_28_1_:%.+]] = arith.muli [[in0_]], [[in1_]] : i32
 // CHECK:             linalg.yield [[VAR_28_1_]] : i32
 // CHECK:           } -> tensor<4x1xi32>
 // CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [1, 4] : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<1x4xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.fill ins([[PARAM_3_]] : i32) outs([[VAR_5_]] : tensor<1x4xi32>) -> tensor<1x4xi32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]], [[VAR_6_]] : tensor<1x4xi32>, tensor<1x4xi32>) outs([[VAR_expanded_0_]] : tensor<1x4xi32>) {
-// CHECK:           ^bb0([[in_]]: i32, [[in_]]_1: i32, [[out_]]: i32):
-// CHECK:             [[VAR_28_2_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[in1_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             [[VAR_28_2_:%.+]] = arith.muli [[in0_]], [[in1_]] : i32
 // CHECK:             linalg.yield [[VAR_28_2_]] : i32
 // CHECK:           } -> tensor<1x4xi32>
 // CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<4x4xi32>
 // CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_4_]] : tensor<4x1xi32>) outs([[VAR_8_]] : tensor<4x4xi32>) attrs =  {broadcastDims = array<i64: 1>} {
-// CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
-// CHECK:             linalg.yield [[in_]] : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             linalg.yield [[in0_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
 // CHECK:           [[VAR_10_:%.+]] = tensor.empty() : tensor<4x4xi32>
 // CHECK:           [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map3, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_7_]] : tensor<1x4xi32>) outs([[VAR_10_]] : tensor<4x4xi32>) attrs =  {broadcastDims = array<i64: 0>} {
-// CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
-// CHECK:             linalg.yield [[in_]] : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             linalg.yield [[in0_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
 // CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_9_]], [[VAR_11_]] : tensor<4x4xi32>, tensor<4x4xi32>) outs([[VAR_9_]] : tensor<4x4xi32>) {
-// CHECK:           ^bb0([[in_]]: i32, [[in_]]_1: i32, [[out_]]: i32):
-// CHECK:             [[VAR_28_3_:%.+]] = arith.addi [[in_]], [[in_]]_1 : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[in1_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             [[VAR_28_3_:%.+]] = arith.addi [[in0_]], [[in1_]] : i32
 // CHECK:             linalg.yield [[VAR_28_3_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
 // CHECK:           [[VAR_13_:%.+]] = tensor.empty() : tensor<4x4x!tt.ptr<f32>>
 // CHECK:           [[VAR_14_:%.+]] = linalg.fill ins([[PARAM_0_]] : !tt.ptr<f32>) outs([[VAR_13_]] : tensor<4x4x!tt.ptr<f32>>) -> tensor<4x4x!tt.ptr<f32>>
 // CHECK:           [[VAR_15_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_14_]], [[VAR_12_]] : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>) outs([[VAR_14_]] : tensor<4x4x!tt.ptr<f32>>) {
-// CHECK:           ^bb0([[in_]]: !tt.ptr<f32>, [[in_]]_1: i32, [[out_]]: !tt.ptr<f32>):
-// CHECK:             [[VAR_28_4_:%.+]] = tt.addptr [[in_]], [[in_]]_1 : !tt.ptr<f32>, i32
+// CHECK:           ^bb0([[in0_:%.+]]: !tt.ptr<f32>, [[in1_:%.+]]: i32, [[out_]]: !tt.ptr<f32>):
+// CHECK:             [[VAR_28_4_:%.+]] = tt.addptr [[in0_]], [[in1_]] : !tt.ptr<f32>, i32
 // CHECK:             linalg.yield [[VAR_28_4_]] : !tt.ptr<f32>
 // CHECK:           } -> tensor<4x4x!tt.ptr<f32>>
 // CHECK-DAG:       [[LOAD_VAR_15_MEM_:%.+]] = tt.load [[VAR_15_]] : tensor<4x4x!tt.ptr<f32>>
 // CHECK-DAG:       [[VAR_17_:%.+]] = tensor.empty() : tensor<4x4xi32>
 // CHECK:           [[VAR_18_:%.+]] = linalg.generic {indexing_maps = [#map3, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x4xi32>) outs([[VAR_17_]] : tensor<4x4xi32>) attrs =  {broadcastDims = array<i64: 0>} {
-// CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
-// CHECK:             linalg.yield [[in_]] : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             linalg.yield [[in0_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
-// CHECK:           [[VAR_19_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK:           [[VAR_19_:%.+]] = tensor.empty() : tensor<4x4xf32>
+// CHECK:           [[VAR_19_T_:%.+]] = linalg.transpose ins([[LOAD_VAR_15_MEM_]] : tensor<4x4xf32>) outs([[VAR_19_]] : tensor<4x4xf32>) permutation = [1, 0]
+// CHECK:           [[VAR_20_TEMPTY_:%.+]] = tensor.empty() : tensor<4x4xi32>
+// CHECK:           [[VAR_18_T_:%.+]] = linalg.transpose ins([[VAR_18_]] : tensor<4x4xi32>) outs([[VAR_20_TEMPTY_]] : tensor<4x4xi32>) permutation = [1, 0]
+// CHECK:           [[VAR_20_INITEMPTY_:%.+]] = tensor.empty() : tensor<4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_20_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_19_]] : tensor<4xf32>) -> tensor<4xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_20_INITEMPTY_]] : tensor<4xf32>) -> tensor<4xf32>
 // CHECK-DAG:       [[VAR_21_:%.+]] = tensor.empty() : tensor<4xi32>
 // CHECK:           [[VAR_22_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_21_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[LOAD_VAR_15_MEM_]], [[VAR_18_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_20_]], [[VAR_22_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
-// CHECK:             ([[in_:%.*]]: f32, [[in_1_:%.*]]: i32, [[init_:%.*]]: f32, [[init_2_:%.*]]: i32) {
-// CHECK-DAG:           [[VAR_28_5_:%.+]] = arith.cmpf oeq, [[in_]], [[init_]] : f32
-// CHECK-DAG:           [[VAR_29_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2_]] : i32
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_19_T_]], [[VAR_18_T_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_20_]], [[VAR_22_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [0]
+// CHECK:             ([[in0_:%.+]]: f32, [[in1_:%.+]]: i32, [[init0_:%.+]]: f32, [[init1_:%.+]]: i32) {
+// CHECK-DAG:           [[VAR_28_5_:%.+]] = arith.cmpf oeq, [[in0_]], [[init0_]] : f32
+// CHECK-DAG:           [[VAR_29_1_:%.+]] = arith.cmpi slt, [[in1_]], [[init1_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_30_:%.+]] = arith.andi [[VAR_28_5_]], [[VAR_29_1_]] : i1
-// CHECK-DAG:           [[VAR_31_:%.+]] = arith.cmpf ogt, [[in_]], [[init_]] : f32
+// CHECK-DAG:           [[VAR_31_:%.+]] = arith.cmpf ogt, [[in0_]], [[init0_]] : f32
 // CHECK:               [[VAR_32_:%.+]] = arith.ori [[VAR_31_]], [[VAR_30_]] : i1
-// CHECK-DAG:           [[VAR_33_:%.+]] = arith.select [[VAR_32_]], [[in_]], [[init_]] : f32
-// CHECK-DAG:           [[VAR_34_:%.+]] = arith.select [[VAR_32_]], [[in_1_]], [[init_2_]] : i32
+// CHECK-DAG:           [[VAR_33_:%.+]] = arith.select [[VAR_32_]], [[in0_]], [[init0_]] : f32
+// CHECK-DAG:           [[VAR_34_:%.+]] = arith.select [[VAR_32_]], [[in1_]], [[init1_]] : i32
 // CHECK:               linalg.yield [[VAR_33_]], [[VAR_34_]] : f32, i32
 // CHECK:             }
 // CHECK:           [[VAR_23_:%.+]] = tensor.empty() : tensor<4x!tt.ptr<f32>>
 // CHECK:           [[VAR_24_:%.+]] = linalg.fill ins([[PARAM_1_]] : !tt.ptr<f32>) outs([[VAR_23_]] : tensor<4x!tt.ptr<f32>>) -> tensor<4x!tt.ptr<f32>>
 // CHECK:           [[VAR_25_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_24_]], [[VAR_1_]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>) outs([[VAR_24_]] : tensor<4x!tt.ptr<f32>>) {
-// CHECK:           ^bb0([[in_]]: !tt.ptr<f32>, [[in_]]_1: i32, [[out_]]: !tt.ptr<f32>):
-// CHECK:             [[VAR_28_6_:%.+]] = tt.addptr [[in_]], [[in_]]_1 : !tt.ptr<f32>, i32
+// CHECK:           ^bb0([[in0_:%.+]]: !tt.ptr<f32>, [[in1_:%.+]]: i32, [[out_]]: !tt.ptr<f32>):
+// CHECK:             [[VAR_28_6_:%.+]] = tt.addptr [[in0_]], [[in1_]] : !tt.ptr<f32>, i32
 // CHECK:             linalg.yield [[VAR_28_6_]] : !tt.ptr<f32>
 // CHECK:           } -> tensor<4x!tt.ptr<f32>>
 // CHECK:           [[VAR_26_:%.+]] = tensor.empty() : tensor<4xf32>
 // CHECK:           [[VAR_27_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_26_]] : tensor<4xf32>) {
-// CHECK:           ^bb0([[in_]]: i32, [[out_]]: f32):
-// CHECK:             [[VAR_28_7_:%.+]] = arith.sitofp [[in_]] : i32 to f32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[out_]]: f32):
+// CHECK:             [[VAR_28_7_:%.+]] = arith.sitofp [[in0_]] : i32 to f32
 // CHECK:             linalg.yield [[VAR_28_7_]] : f32
 // CHECK:           } -> tensor<4xf32>
 // CHECK:           tt.store [[VAR_25_]], [[VAR_27_]] : tensor<4x!tt.ptr<f32>>
@@ -218,74 +222,78 @@ module {
 // CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<4x1xi32>
 // CHECK:           [[VAR_3_:%.+]] = linalg.fill ins([[PARAM_2_]] : i32) outs([[VAR_2_]] : tensor<4x1xi32>) -> tensor<4x1xi32>
 // CHECK:           [[VAR_4_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_]], [[VAR_3_]] : tensor<4x1xi32>, tensor<4x1xi32>) outs([[VAR_expanded_]] : tensor<4x1xi32>) {
-// CHECK:           ^bb0([[in_]]: i32, [[in_]]_1: i32, [[out_]]: i32):
-// CHECK:             [[VAR_28_1_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[in1_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             [[VAR_28_1_:%.+]] = arith.muli [[in0_]], [[in1_]] : i32
 // CHECK:             linalg.yield [[VAR_28_1_]] : i32
 // CHECK:           } -> tensor<4x1xi32>
 // CHECK-DAG:       [[VAR_expanded_0_:%.+]] = tensor.expand_shape [[VAR_1_]] {{.}}[0, 1]{{.}} output_shape [1, 4] : tensor<4xi32> into tensor<1x4xi32>
 // CHECK-DAG:       [[VAR_5_:%.+]] = tensor.empty() : tensor<1x4xi32>
 // CHECK:           [[VAR_6_:%.+]] = linalg.fill ins([[PARAM_3_]] : i32) outs([[VAR_5_]] : tensor<1x4xi32>) -> tensor<1x4xi32>
 // CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]], [[VAR_6_]] : tensor<1x4xi32>, tensor<1x4xi32>) outs([[VAR_expanded_0_]] : tensor<1x4xi32>) {
-// CHECK:           ^bb0([[in_]]: i32, [[in_]]_1: i32, [[out_]]: i32):
-// CHECK:             [[VAR_28_2_:%.+]] = arith.muli [[in_]], [[in_]]_1 : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[in1_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             [[VAR_28_2_:%.+]] = arith.muli [[in0_]], [[in1_]] : i32
 // CHECK:             linalg.yield [[VAR_28_2_]] : i32
 // CHECK:           } -> tensor<1x4xi32>
 // CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<4x4xi32>
 // CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_4_]] : tensor<4x1xi32>) outs([[VAR_8_]] : tensor<4x4xi32>) attrs =  {broadcastDims = array<i64: 1>} {
-// CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
-// CHECK:             linalg.yield [[in_]] : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             linalg.yield [[in0_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
 // CHECK:           [[VAR_10_:%.+]] = tensor.empty() : tensor<4x4xi32>
 // CHECK:           [[VAR_11_:%.+]] = linalg.generic {indexing_maps = [#map3, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_7_]] : tensor<1x4xi32>) outs([[VAR_10_]] : tensor<4x4xi32>) attrs =  {broadcastDims = array<i64: 0>} {
-// CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
-// CHECK:             linalg.yield [[in_]] : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             linalg.yield [[in0_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
 // CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_9_]], [[VAR_11_]] : tensor<4x4xi32>, tensor<4x4xi32>) outs([[VAR_9_]] : tensor<4x4xi32>) {
-// CHECK:           ^bb0([[in_]]: i32, [[in_]]_1: i32, [[out_]]: i32):
-// CHECK:             [[VAR_28_3_:%.+]] = arith.addi [[in_]], [[in_]]_1 : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[in1_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             [[VAR_28_3_:%.+]] = arith.addi [[in0_]], [[in1_]] : i32
 // CHECK:             linalg.yield [[VAR_28_3_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
 // CHECK:           [[VAR_13_:%.+]] = tensor.empty() : tensor<4x4x!tt.ptr<f32>>
 // CHECK:           [[VAR_14_:%.+]] = linalg.fill ins([[PARAM_0_]] : !tt.ptr<f32>) outs([[VAR_13_]] : tensor<4x4x!tt.ptr<f32>>) -> tensor<4x4x!tt.ptr<f32>>
 // CHECK:           [[VAR_15_:%.+]] = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_14_]], [[VAR_12_]] : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>) outs([[VAR_14_]] : tensor<4x4x!tt.ptr<f32>>) {
-// CHECK:           ^bb0([[in_]]: !tt.ptr<f32>, [[in_]]_1: i32, [[out_]]: !tt.ptr<f32>):
-// CHECK:             [[VAR_28_4_:%.+]] = tt.addptr [[in_]], [[in_]]_1 : !tt.ptr<f32>, i32
+// CHECK:           ^bb0([[in0_:%.+]]: !tt.ptr<f32>, [[in1_:%.+]]: i32, [[out_]]: !tt.ptr<f32>):
+// CHECK:             [[VAR_28_4_:%.+]] = tt.addptr [[in0_]], [[in1_]] : !tt.ptr<f32>, i32
 // CHECK:             linalg.yield [[VAR_28_4_]] : !tt.ptr<f32>
 // CHECK:           } -> tensor<4x4x!tt.ptr<f32>>
 // CHECK-DAG:       [[LOAD_VAR_15_MEM_:%.+]] = tt.load [[VAR_15_]] : tensor<4x4x!tt.ptr<f32>>
 // CHECK-DAG:       [[VAR_17_:%.+]] = tensor.empty() : tensor<4x4xi32>
 // CHECK:           [[VAR_18_:%.+]] = linalg.generic {indexing_maps = [#map3, #map1], iterator_types = ["parallel", "parallel"]} ins([[VAR_expanded_0_]] : tensor<1x4xi32>) outs([[VAR_17_]] : tensor<4x4xi32>) attrs =  {broadcastDims = array<i64: 0>} {
-// CHECK:           ^bb0([[in_]]: i32, [[out_]]: i32):
-// CHECK:             linalg.yield [[in_]] : i32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[out_]]: i32):
+// CHECK:             linalg.yield [[in0_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
-// CHECK:           [[VAR_19_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK:           [[VAR_19_:%.+]] = tensor.empty() : tensor<4x4xf32>
+// CHECK:           [[VAR_19_T_:%.+]] = linalg.transpose ins([[LOAD_VAR_15_MEM_]] : tensor<4x4xf32>) outs([[VAR_19_]] : tensor<4x4xf32>) permutation = [1, 0]
+// CHECK:           [[VAR_20_TEMPTY_:%.+]] = tensor.empty() : tensor<4x4xi32>
+// CHECK:           [[VAR_18_T_:%.+]] = linalg.transpose ins([[VAR_18_]] : tensor<4x4xi32>) outs([[VAR_20_TEMPTY_]] : tensor<4x4xi32>) permutation = [1, 0]
+// CHECK:           [[VAR_20_INITEMPTY_:%.+]] = tensor.empty() : tensor<4xf32>
 // CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_20_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_19_]] : tensor<4xf32>) -> tensor<4xf32>
+// CHECK-DAG:       [[VAR_20_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_20_INITEMPTY_]] : tensor<4xf32>) -> tensor<4xf32>
 // CHECK-DAG:       [[VAR_21_:%.+]] = tensor.empty() : tensor<4xi32>
 // CHECK:           [[VAR_22_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_21_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[LOAD_VAR_15_MEM_]], [[VAR_18_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_20_]], [[VAR_22_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
-// CHECK:             ([[in_]]: f32, [[in_]]_1: i32, [[in_]]it: f32, [[in_]]it_2: i32) {
-// CHECK-DAG:           [[VAR_28_5_:%.+]] = arith.cmpf oeq, [[in_]], [[in_]]it : f32
-// CHECK-DAG:           [[VAR_29_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2_]] : i32
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_19_T_]], [[VAR_18_T_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_20_]], [[VAR_22_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [0]
+// CHECK:             ([[in0_:%.+]]: f32, [[in1_:%.+]]: i32, [[init0_:%.+]]: f32, [[init1_:%.+]]: i32) {
+// CHECK-DAG:           [[VAR_28_5_:%.+]] = arith.cmpf oeq, [[in0_]], [[init0_]] : f32
+// CHECK-DAG:           [[VAR_29_1_:%.+]] = arith.cmpi slt, [[in1_]], [[init1_]] : i32
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:           [[VAR_30_:%.+]] = arith.andi [[VAR_28_5_]], [[VAR_29_1_]] : i1
-// CHECK-DAG:           [[VAR_31_:%.+]] = arith.cmpf olt, [[in_]], [[in_]]it : f32
+// CHECK-DAG:           [[VAR_31_:%.+]] = arith.cmpf olt, [[in0_]], [[init0_]] : f32
 // CHECK:               [[VAR_32_:%.+]] = arith.ori [[VAR_31_]], [[VAR_30_]] : i1
-// CHECK-DAG:           [[VAR_33_:%.+]] = arith.select [[VAR_32_]], [[in_]], [[in_]]it : f32
-// CHECK-DAG:           [[VAR_34_:%.+]] = arith.select [[VAR_32_]], [[in_1_]], [[init_2_]] : i32
+// CHECK-DAG:           [[VAR_33_:%.+]] = arith.select [[VAR_32_]], [[in0_]], [[init0_]] : f32
+// CHECK-DAG:           [[VAR_34_:%.+]] = arith.select [[VAR_32_]], [[in1_]], [[init1_]] : i32
 // CHECK:               linalg.yield [[VAR_33_]], [[VAR_34_]] : f32, i32
 // CHECK:             }
 // CHECK:           [[VAR_23_:%.+]] = tensor.empty() : tensor<4x!tt.ptr<f32>>
 // CHECK:           [[VAR_24_:%.+]] = linalg.fill ins([[PARAM_1_]] : !tt.ptr<f32>) outs([[VAR_23_]] : tensor<4x!tt.ptr<f32>>) -> tensor<4x!tt.ptr<f32>>
 // CHECK:           [[VAR_25_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_24_]], [[VAR_1_]] : tensor<4x!tt.ptr<f32>>, tensor<4xi32>) outs([[VAR_24_]] : tensor<4x!tt.ptr<f32>>) {
-// CHECK:           ^bb0([[in_]]: !tt.ptr<f32>, [[in_]]_1: i32, [[out_]]: !tt.ptr<f32>):
-// CHECK:             [[VAR_28_6_:%.+]] = tt.addptr [[in_]], [[in_]]_1 : !tt.ptr<f32>, i32
+// CHECK:           ^bb0([[in0_:%.+]]: !tt.ptr<f32>, [[in1_:%.+]]: i32, [[out_]]: !tt.ptr<f32>):
+// CHECK:             [[VAR_28_6_:%.+]] = tt.addptr [[in0_]], [[in1_]] : !tt.ptr<f32>, i32
 // CHECK:             linalg.yield [[VAR_28_6_]] : !tt.ptr<f32>
 // CHECK:           } -> tensor<4x!tt.ptr<f32>>
 // CHECK:           [[VAR_26_:%.+]] = tensor.empty() : tensor<4xf32>
 // CHECK:           [[VAR_27_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_26_]] : tensor<4xf32>) {
-// CHECK:           ^bb0([[in_]]: i32, [[out_]]: f32):
-// CHECK:             [[VAR_28_7_:%.+]] = arith.sitofp [[in_]] : i32 to f32
+// CHECK:           ^bb0([[in0_:%.+]]: i32, [[out_]]: f32):
+// CHECK:             [[VAR_28_7_:%.+]] = arith.sitofp [[in0_]] : i32 to f32
 // CHECK:             linalg.yield [[VAR_28_7_]] : f32
 // CHECK:           } -> tensor<4xf32>
 // CHECK:           tt.store [[VAR_25_]], [[VAR_27_]] : tensor<4x!tt.ptr<f32>>

--- a/test/Conversion/TritonArithToLinalg/convert_minmax_fp_reduce.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_minmax_fp_reduce.mlir
@@ -37,9 +37,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<4096xf32>) -> tensor<4096xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK:           [[VAR_init_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_2_]] : tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xf32>) outs([[VAR_init_]] : tensor<f32>) dimensions = [0]
 // CHECK:             ([[in_:%.+]]: f32, [[in_]]it: f32) {
 // CHECK:               [[VAR_3_:%.+]] = arith.maxnumf [[in_]], [[in_]]it : f32
 // CHECK:               linalg.yield [[VAR_3_]] : f32
@@ -55,9 +55,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xf32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<4096xf32>) -> tensor<4096xf32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK:           [[VAR_init_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_2_]] : tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xf32>) outs([[VAR_init_]] : tensor<f32>) dimensions = [0]
 // CHECK:             ([[in_:%.+]]: f32, [[in_]]it: f32) {
 // CHECK:               [[VAR_3_:%.+]] = arith.minnumf [[in_]], [[in_]]it : f32
 // CHECK:               linalg.yield [[VAR_3_]] : f32

--- a/test/Conversion/TritonArithToLinalg/convert_minmax_reduce.mlir
+++ b/test/Conversion/TritonArithToLinalg/convert_minmax_reduce.mlir
@@ -71,9 +71,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_minus_2147483648_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<i32>
+// CHECK:           [[VAR_init_:%.+]] = linalg.fill ins([[CST_minus_2147483648_]] : i32) outs([[VAR_2_]] : tensor<i32>) -> tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_init_]] : tensor<i32>) dimensions = [0]
 // CHECK:             ([[in_:%.+]]: i32, [[in_]]it: i32) {
 // CHECK:               [[VAR_3_:%.+]] = arith.maxsi [[in_]], [[in_]]it : i32
 // CHECK:               linalg.yield [[VAR_3_]] : i32
@@ -88,9 +88,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<i32>
+// CHECK:           [[VAR_init_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_2_]] : tensor<i32>) -> tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_init_]] : tensor<i32>) dimensions = [0]
 // CHECK:             ([[in_:%.+]]: i32, [[in_]]it: i32) {
 // CHECK:               [[VAR_3_:%.+]] = arith.maxui [[in_]], [[in_]]it : i32
 // CHECK:               linalg.yield [[VAR_3_]] : i32
@@ -106,9 +106,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_2147483647_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<i32>
+// CHECK:           [[VAR_init_:%.+]] = linalg.fill ins([[CST_2147483647_]] : i32) outs([[VAR_2_]] : tensor<i32>) -> tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_init_]] : tensor<i32>) dimensions = [0]
 // CHECK:             ([[in_:%.+]]: i32, [[in_]]it: i32) {
 // CHECK:               [[VAR_3_:%.+]] = arith.minsi [[in_]], [[in_]]it : i32
 // CHECK:               linalg.yield [[VAR_3_]] : i32
@@ -124,9 +124,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<4096xi32>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_]] : i32) outs([[VAR_0_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_minus_1_]] into [[VAR_2_]][] : tensor<i32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_inserted_]] : tensor<i32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<i32>
+// CHECK:           [[VAR_init_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_2_]] : tensor<i32>) -> tensor<i32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<4096xi32>) outs([[VAR_init_]] : tensor<i32>) dimensions = [0]
 // CHECK:             ([[in_:%.+]]: i32, [[in_]]it: i32) {
 // CHECK:               [[VAR_3_:%.+]] = arith.minui [[in_]], [[in_]]it : i32
 // CHECK:               linalg.yield [[VAR_3_]] : i32

--- a/test/Conversion/TritonArithToLinalg/cumsum.mlir
+++ b/test/Conversion/TritonArithToLinalg/cumsum.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-shared-opt --triton-arith-to-linalg %s | FileCheck %s
+// RUN: triton-shared-opt --triton-arith-to-linalg --split-input-file %s | FileCheck %s
 
 // @triton.jit
 // def test_cumsum_op(
@@ -20,6 +20,68 @@
 // print(ret.asm["ttir"])
 
 module {
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:   func.func @test_cumsum_op_012(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !tt.ptr<f32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !tt.ptr<i32>,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG8:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4096 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : index
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : index
+// CHECK:           %[[MULI_0:.*]] = arith.muli %[[ARG6]], %[[ARG2]] : i32
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]]], iterator_types = ["parallel"]} outs(%[[EMPTY_0]] : tensor<4096xi32>) {
+// CHECK:           ^bb0(%[[VAL_0:.*]]: i32):
+// CHECK:             %[[INDEX_0:.*]] = linalg.index 0 : index
+// CHECK:             %[[INDEX_CAST_0:.*]] = arith.index_cast %[[INDEX_0]] : index to i32
+// CHECK:             linalg.yield %[[INDEX_CAST_0]] : i32
+// CHECK:           } -> tensor<4096xi32>
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[MULI_0]] : i32) outs(%[[EMPTY_1]] : tensor<4096xi32>) -> tensor<4096xi32>
+// CHECK:           %[[GENERIC_1:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[FILL_0]], %[[GENERIC_0]] : tensor<4096xi32>, tensor<4096xi32>) outs(%[[FILL_0]] : tensor<4096xi32>) {
+// CHECK:           ^bb0(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32):
+// CHECK:             %[[ADDI_0:.*]] = arith.addi %[[VAL_1]], %[[VAL_2]] : i32
+// CHECK:             linalg.yield %[[ADDI_0]] : i32
+// CHECK:           } -> tensor<4096xi32>
+// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<4096x!tt.ptr<f32>>
+// CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[ARG0]] : !tt.ptr<f32>) outs(%[[EMPTY_2]] : tensor<4096x!tt.ptr<f32>>) -> tensor<4096x!tt.ptr<f32>>
+// CHECK:           %[[GENERIC_2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[FILL_1]], %[[GENERIC_1]] : tensor<4096x!tt.ptr<f32>>, tensor<4096xi32>) outs(%[[FILL_1]] : tensor<4096x!tt.ptr<f32>>) {
+// CHECK:           ^bb0(%[[VAL_4:.*]]: !tt.ptr<f32>, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: !tt.ptr<f32>):
+// CHECK:             %[[ADDPTR_0:.*]] = tt.addptr %[[VAL_4]], %[[VAL_5]] : !tt.ptr<f32>, i32
+// CHECK:             linalg.yield %[[ADDPTR_0]] : !tt.ptr<f32>
+// CHECK:           } -> tensor<4096x!tt.ptr<f32>>
+// CHECK:           %[[LOAD_0:.*]] = tt.load %[[GENERIC_2]] : tensor<4096x!tt.ptr<f32>>
+// CHECK:           %[[EMPTY_3:.*]] = tensor.empty() : tensor<4096xf32>
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[LOAD_0]]{{\[}}%[[CONSTANT_2]]] : tensor<4096xf32>
+// CHECK:           %[[INSERT_0:.*]] = tensor.insert %[[EXTRACT_0]] into %[[EMPTY_3]]{{\[}}%[[CONSTANT_2]]] : tensor<4096xf32>
+// CHECK:           %[[FOR_0:.*]]:2 = scf.for %[[VAL_7:.*]] = %[[CONSTANT_1]] to %[[CONSTANT_0]] step %[[CONSTANT_1]] iter_args(%[[VAL_8:.*]] = %[[EXTRACT_0]], %[[VAL_9:.*]] = %[[INSERT_0]]) -> (f32, tensor<4096xf32>) {
+// CHECK:             %[[EXTRACT_1:.*]] = tensor.extract %[[LOAD_0]]{{\[}}%[[VAL_7]]] : tensor<4096xf32>
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[VAL_8]], %[[EXTRACT_1]] : f32
+// CHECK:             %[[INSERT_1:.*]] = tensor.insert %[[ADDF_0]] into %[[VAL_9]]{{\[}}%[[VAL_7]]] : tensor<4096xf32>
+// CHECK:             scf.yield %[[ADDF_0]], %[[INSERT_1]] : f32, tensor<4096xf32>
+// CHECK:           }
+// CHECK:           %[[EMPTY_4:.*]] = tensor.empty() : tensor<4096x!tt.ptr<i32>>
+// CHECK:           %[[FILL_2:.*]] = linalg.fill ins(%[[ARG1]] : !tt.ptr<i32>) outs(%[[EMPTY_4]] : tensor<4096x!tt.ptr<i32>>) -> tensor<4096x!tt.ptr<i32>>
+// CHECK:           %[[GENERIC_3:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[FILL_2]], %[[GENERIC_1]] : tensor<4096x!tt.ptr<i32>>, tensor<4096xi32>) outs(%[[FILL_2]] : tensor<4096x!tt.ptr<i32>>) {
+// CHECK:           ^bb0(%[[VAL_10:.*]]: !tt.ptr<i32>, %[[VAL_11:.*]]: i32, %[[VAL_12:.*]]: !tt.ptr<i32>):
+// CHECK:             %[[ADDPTR_1:.*]] = tt.addptr %[[VAL_10]], %[[VAL_11]] : !tt.ptr<i32>, i32
+// CHECK:             linalg.yield %[[ADDPTR_1]] : !tt.ptr<i32>
+// CHECK:           } -> tensor<4096x!tt.ptr<i32>>
+// CHECK:           %[[EMPTY_5:.*]] = tensor.empty() : tensor<4096xi32>
+// CHECK:           %[[GENERIC_4:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], iterator_types = ["parallel"]} ins(%[[VAL_13:.*]]#1 : tensor<4096xf32>) outs(%[[EMPTY_5]] : tensor<4096xi32>) {
+// CHECK:           ^bb0(%[[VAL_14:.*]]: f32, %[[VAL_15:.*]]: i32):
+// CHECK:             %[[FPTOSI_0:.*]] = arith.fptosi %[[VAL_14]] : f32 to i32
+// CHECK:             linalg.yield %[[FPTOSI_0]] : i32
+// CHECK:           } -> tensor<4096xi32>
+// CHECK:           tt.store %[[GENERIC_3]], %[[GENERIC_4]] : tensor<4096x!tt.ptr<i32>>
+// CHECK:           return
+// CHECK:         }
   tt.func public @test_cumsum_op_012(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<i32>, %arg2: i32) attributes {noinline = false} {
     %0 = tt.get_program_id x : i32
     %1 = arith.muli %0, %arg2 : i32
@@ -42,48 +104,163 @@ module {
   }
 }
 
-// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
-// CHECK-LABEL:  func.func @test_cumsum_op_012
-// CHECK-SAME:   ([[PARAM_0_:%.+]]: !tt.ptr<f32>, [[PARAM_1_:%.+]]: !tt.ptr<i32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
-// CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_6_]], [[PARAM_2_]] : i32
-// CHECK-DAG:       [[VAR_1_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK:           [[VAR_2_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_1_]] : tensor<4096xi32>) {
-// CHECK:           ^bb0([[out_:%.+]]: i32):
-// CHECK:             [[VAR_17_:%.+]] = linalg.index 0 : index
-// CHECK:             [[VAR_18_:%.+]] = arith.index_cast [[VAR_17_]] : index to i32
-// CHECK:             linalg.yield [[VAR_18_]] : i32
-// CHECK:           } -> tensor<4096xi32>
-// CHECK:           [[VAR_3_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK:           [[VAR_4_:%.+]] = linalg.fill ins([[VAR_0_]] : i32) outs([[VAR_3_]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK:           [[VAR_5_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_4_]], [[VAR_2_]] : tensor<4096xi32>, tensor<4096xi32>) outs([[VAR_4_]] : tensor<4096xi32>) {
-// CHECK:           ^bb0([[in_:%.+]]: i32, [[in_]]_0: i32, [[out_]]: i32):
-// CHECK:             [[VAR_17_1_:%.+]] = arith.addi [[in_]], [[in_]]_0 : i32
-// CHECK:             linalg.yield [[VAR_17_1_]] : i32
-// CHECK:           } -> tensor<4096xi32>
-// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<4096x!tt.ptr<f32>>
-// CHECK:           [[VAR_7_:%.+]] = linalg.fill ins([[PARAM_0_]] : !tt.ptr<f32>) outs([[VAR_6_]] : tensor<4096x!tt.ptr<f32>>) -> tensor<4096x!tt.ptr<f32>>
-// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_7_]], [[VAR_5_]] : tensor<4096x!tt.ptr<f32>>, tensor<4096xi32>) outs([[VAR_7_]] : tensor<4096x!tt.ptr<f32>>) {
-// CHECK:           ^bb0([[in_]]: !tt.ptr<f32>, [[in_]]_0: i32, [[out_]]: !tt.ptr<f32>):
-// CHECK:             [[VAR_17_2_:%.+]] = tt.addptr [[in_]], [[in_]]_0 : !tt.ptr<f32>, i32
-// CHECK:             linalg.yield [[VAR_17_2_]] : !tt.ptr<f32>
-// CHECK:           } -> tensor<4096x!tt.ptr<f32>>
-// CHECK-DAG:       [[LOAD_VAR_8_MEM_:%.+]] = tt.load [[VAR_8_]] : tensor<4096x!tt.ptr<f32>>
-// CHECK-DAG:       [[VAR_10_:%.+]] = tensor.empty() : tensor<4096xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_11_:%.+]] = ttx.cumsum {axis = 0 : ui32, operandSegmentSizes = array<i32: 1, 1>} ins([[LOAD_VAR_8_MEM_]] : tensor<4096xf32>) outs([[VAR_10_]] : tensor<4096xf32>) -> tensor<4096xf32>
-// CHECK-DAG:       [[VAR_12_:%.+]] = tensor.empty() : tensor<4096x!tt.ptr<i32>>
-// CHECK:           [[VAR_13_:%.+]] = linalg.fill ins([[PARAM_1_]] : !tt.ptr<i32>) outs([[VAR_12_]] : tensor<4096x!tt.ptr<i32>>) -> tensor<4096x!tt.ptr<i32>>
-// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_13_]], [[VAR_5_]] : tensor<4096x!tt.ptr<i32>>, tensor<4096xi32>) outs([[VAR_13_]] : tensor<4096x!tt.ptr<i32>>) {
-// CHECK:           ^bb0([[in_]]: !tt.ptr<i32>, [[in_]]_0: i32, [[out_]]: !tt.ptr<i32>):
-// CHECK:             [[VAR_17_3_:%.+]] = tt.addptr [[in_]], [[in_]]_0 : !tt.ptr<i32>, i32
-// CHECK:             linalg.yield [[VAR_17_3_]] : !tt.ptr<i32>
-// CHECK:           } -> tensor<4096x!tt.ptr<i32>>
-// CHECK:           [[VAR_15_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK:           [[VAR_16_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_11_]] : tensor<4096xf32>) outs([[VAR_15_]] : tensor<4096xi32>) {
-// CHECK:           ^bb0([[in_]]: f32, [[out_]]: i32):
-// CHECK:             [[VAR_17_4_:%.+]] = arith.fptosi [[in_]] : f32 to i32
-// CHECK:             linalg.yield [[VAR_17_4_]] : i32
-// CHECK:           } -> tensor<4096xi32>
-// CHECK:           tt.store [[VAR_14_]], [[VAR_16_]] : tensor<4096x!tt.ptr<i32>>
-// CHECK:           return
+// -----
+
+module {
+// CHECK-LABEL:   func.func @scan_forward_rank1(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: tensor<4xf32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) -> tensor<4xf32> {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 1 : index
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 0 : index
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4xf32>
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[CONSTANT_2]]] : tensor<4xf32>
+// CHECK:           %[[INSERT_0:.*]] = tensor.insert %[[EXTRACT_0]] into %[[EMPTY_0]]{{\[}}%[[CONSTANT_2]]] : tensor<4xf32>
+// CHECK:           %[[FOR_0:.*]]:2 = scf.for %[[VAL_0:.*]] = %[[CONSTANT_1]] to %[[CONSTANT_0]] step %[[CONSTANT_1]] iter_args(%[[VAL_1:.*]] = %[[EXTRACT_0]], %[[VAL_2:.*]] = %[[INSERT_0]]) -> (f32, tensor<4xf32>) {
+// CHECK:             %[[EXTRACT_1:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[VAL_0]]] : tensor<4xf32>
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[VAL_1]], %[[EXTRACT_1]] : f32
+// CHECK:             %[[INSERT_1:.*]] = tensor.insert %[[ADDF_0]] into %[[VAL_2]]{{\[}}%[[VAL_0]]] : tensor<4xf32>
+// CHECK:             scf.yield %[[ADDF_0]], %[[INSERT_1]] : f32, tensor<4xf32>
+// CHECK:           }
+// CHECK:           return %[[VAL_3:.*]]#1 : tensor<4xf32>
 // CHECK:         }
+  tt.func @scan_forward_rank1(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    %0 = "tt.scan"(%arg0) <{axis = 0 : i32, reverse = false}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.addf %arg1, %arg2 : f32
+      tt.scan.return %1 : f32
+    }) : (tensor<4xf32>) -> tensor<4xf32>
+    tt.return %0 : tensor<4xf32>
+  }
+}
+
+// -----
+
+module {
+// CHECK-LABEL:   func.func @scan_reverse_rank1(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: tensor<4xf32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) -> tensor<4xf32> {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 3 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 4 : index
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 1 : index
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<4xf32>
+// CHECK:           %[[EXTRACT_0:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[CONSTANT_0]]] : tensor<4xf32>
+// CHECK:           %[[INSERT_0:.*]] = tensor.insert %[[EXTRACT_0]] into %[[EMPTY_0]]{{\[}}%[[CONSTANT_0]]] : tensor<4xf32>
+// CHECK:           %[[FOR_0:.*]]:2 = scf.for %[[VAL_0:.*]] = %[[CONSTANT_2]] to %[[CONSTANT_1]] step %[[CONSTANT_2]] iter_args(%[[VAL_1:.*]] = %[[EXTRACT_0]], %[[VAL_2:.*]] = %[[INSERT_0]]) -> (f32, tensor<4xf32>) {
+// CHECK:             %[[SUBI_0:.*]] = arith.subi %[[CONSTANT_1]], %[[VAL_0]] : index
+// CHECK:             %[[SUBI_1:.*]] = arith.subi %[[SUBI_0]], %[[CONSTANT_2]] : index
+// CHECK:             %[[EXTRACT_1:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[SUBI_1]]] : tensor<4xf32>
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[VAL_1]], %[[EXTRACT_1]] : f32
+// CHECK:             %[[INSERT_1:.*]] = tensor.insert %[[ADDF_0]] into %[[VAL_2]]{{\[}}%[[SUBI_1]]] : tensor<4xf32>
+// CHECK:             scf.yield %[[ADDF_0]], %[[INSERT_1]] : f32, tensor<4xf32>
+// CHECK:           }
+// CHECK:           return %[[VAL_3:.*]]#1 : tensor<4xf32>
+// CHECK:         }
+  tt.func @scan_reverse_rank1(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    %0 = "tt.scan"(%arg0) <{axis = 0 : i32, reverse = true}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.addf %arg1, %arg2 : f32
+      tt.scan.return %1 : f32
+    }) : (tensor<4xf32>) -> tensor<4xf32>
+    tt.return %0 : tensor<4xf32>
+  }
+}
+
+// -----
+
+module {
+// CHECK-LABEL:   func.func @scan_forward_rank2(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: tensor<2x4xf32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) -> tensor<2x4xf32> {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 4 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 2 : index
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 1 : index
+// CHECK:           %[[CONSTANT_3:.*]] = arith.constant 0 : index
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<2x4xf32>
+// CHECK:           %[[FOR_0:.*]] = scf.for %[[VAL_0:.*]] = %[[CONSTANT_3]] to %[[CONSTANT_1]] step %[[CONSTANT_2]] iter_args(%[[VAL_1:.*]] = %[[EMPTY_0]]) -> (tensor<2x4xf32>) {
+// CHECK:             %[[EXTRACT_0:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[VAL_0]], %[[CONSTANT_3]]] : tensor<2x4xf32>
+// CHECK:             %[[INSERT_0:.*]] = tensor.insert %[[EXTRACT_0]] into %[[VAL_1]]{{\[}}%[[VAL_0]], %[[CONSTANT_3]]] : tensor<2x4xf32>
+// CHECK:             %[[FOR_1:.*]]:2 = scf.for %[[VAL_2:.*]] = %[[CONSTANT_2]] to %[[CONSTANT_0]] step %[[CONSTANT_2]] iter_args(%[[VAL_3:.*]] = %[[EXTRACT_0]], %[[VAL_4:.*]] = %[[INSERT_0]]) -> (f32, tensor<2x4xf32>) {
+// CHECK:               %[[EXTRACT_1:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[VAL_0]], %[[VAL_2]]] : tensor<2x4xf32>
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_3]], %[[EXTRACT_1]] : f32
+// CHECK:               %[[INSERT_1:.*]] = tensor.insert %[[ADDF_0]] into %[[VAL_4]]{{\[}}%[[VAL_0]], %[[VAL_2]]] : tensor<2x4xf32>
+// CHECK:               scf.yield %[[ADDF_0]], %[[INSERT_1]] : f32, tensor<2x4xf32>
+// CHECK:             }
+// CHECK:             scf.yield %[[VAL_5:.*]]#1 : tensor<2x4xf32>
+// CHECK:           }
+// CHECK:           return %[[FOR_0]] : tensor<2x4xf32>
+// CHECK:         }
+  tt.func @scan_forward_rank2(%arg0: tensor<2x4xf32>) -> tensor<2x4xf32> {
+    %0 = "tt.scan"(%arg0) <{axis = 1 : i32, reverse = false}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.addf %arg1, %arg2 : f32
+      tt.scan.return %1 : f32
+    }) : (tensor<2x4xf32>) -> tensor<2x4xf32>
+    tt.return %0 : tensor<2x4xf32>
+  }
+}
+
+// -----
+
+module {
+// CHECK-LABEL:   func.func @scan_reverse_rank2_multi_result(
+// CHECK-SAME:      %[[ARG0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: tensor<2x4xf32>,
+// CHECK-SAME:      %[[ARG1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: tensor<2x4xf32>,
+// CHECK-SAME:      %[[ARG2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) -> (tensor<2x4xf32>, tensor<2x4xf32>) {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 3 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 4 : index
+// CHECK:           %[[CONSTANT_2:.*]] = arith.constant 2 : index
+// CHECK:           %[[CONSTANT_3:.*]] = arith.constant 1 : index
+// CHECK:           %[[CONSTANT_4:.*]] = arith.constant 0 : index
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<2x4xf32>
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<2x4xf32>
+// CHECK:           %[[FOR_0:.*]]:2 = scf.for %[[VAL_0:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_2]] step %[[CONSTANT_3]] iter_args(%[[VAL_1:.*]] = %[[EMPTY_0]], %[[VAL_2:.*]] = %[[EMPTY_1]]) -> (tensor<2x4xf32>, tensor<2x4xf32>) {
+// CHECK:             %[[EXTRACT_0:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[VAL_0]], %[[CONSTANT_0]]] : tensor<2x4xf32>
+// CHECK:             %[[EXTRACT_1:.*]] = tensor.extract %[[ARG1]]{{\[}}%[[VAL_0]], %[[CONSTANT_0]]] : tensor<2x4xf32>
+// CHECK:             %[[INSERT_0:.*]] = tensor.insert %[[EXTRACT_0]] into %[[VAL_1]]{{\[}}%[[VAL_0]], %[[CONSTANT_0]]] : tensor<2x4xf32>
+// CHECK:             %[[INSERT_1:.*]] = tensor.insert %[[EXTRACT_1]] into %[[VAL_2]]{{\[}}%[[VAL_0]], %[[CONSTANT_0]]] : tensor<2x4xf32>
+// CHECK:             %[[FOR_1:.*]]:4 = scf.for %[[VAL_3:.*]] = %[[CONSTANT_3]] to %[[CONSTANT_1]] step %[[CONSTANT_3]] iter_args(%[[VAL_4:.*]] = %[[EXTRACT_0]], %[[VAL_5:.*]] = %[[EXTRACT_1]], %[[VAL_6:.*]] = %[[INSERT_0]], %[[VAL_7:.*]] = %[[INSERT_1]]) -> (f32, f32, tensor<2x4xf32>, tensor<2x4xf32>) {
+// CHECK:               %[[SUBI_0:.*]] = arith.subi %[[CONSTANT_1]], %[[VAL_3]] : index
+// CHECK:               %[[SUBI_1:.*]] = arith.subi %[[SUBI_0]], %[[CONSTANT_3]] : index
+// CHECK:               %[[EXTRACT_2:.*]] = tensor.extract %[[ARG0]]{{\[}}%[[VAL_0]], %[[SUBI_1]]] : tensor<2x4xf32>
+// CHECK:               %[[EXTRACT_3:.*]] = tensor.extract %[[ARG1]]{{\[}}%[[VAL_0]], %[[SUBI_1]]] : tensor<2x4xf32>
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_4]], %[[EXTRACT_2]] : f32
+// CHECK:               %[[MAXIMUMF_0:.*]] = arith.maximumf %[[VAL_5]], %[[EXTRACT_3]] : f32
+// CHECK:               %[[INSERT_2:.*]] = tensor.insert %[[ADDF_0]] into %[[VAL_6]]{{\[}}%[[VAL_0]], %[[SUBI_1]]] : tensor<2x4xf32>
+// CHECK:               %[[INSERT_3:.*]] = tensor.insert %[[MAXIMUMF_0]] into %[[VAL_7]]{{\[}}%[[VAL_0]], %[[SUBI_1]]] : tensor<2x4xf32>
+// CHECK:               scf.yield %[[ADDF_0]], %[[MAXIMUMF_0]], %[[INSERT_2]], %[[INSERT_3]] : f32, f32, tensor<2x4xf32>, tensor<2x4xf32>
+// CHECK:             }
+// CHECK:             scf.yield %[[VAL_8:.*]]#2, %[[VAL_8]]#3 : tensor<2x4xf32>, tensor<2x4xf32>
+// CHECK:           }
+// CHECK:           return %[[VAL_9:.*]]#0, %[[VAL_9]]#1 : tensor<2x4xf32>, tensor<2x4xf32>
+// CHECK:         }
+  tt.func @scan_reverse_rank2_multi_result(%arg0: tensor<2x4xf32>, %arg1: tensor<2x4xf32>) -> (tensor<2x4xf32>, tensor<2x4xf32>) {
+    %0:2 = "tt.scan"(%arg0, %arg1) <{axis = 1 : i32, reverse = true}> ({
+    ^bb0(%arg2: f32, %arg3: f32, %arg4: f32, %arg5: f32):
+      %1 = arith.addf %arg2, %arg4 : f32
+      %2 = arith.maximumf %arg3, %arg5 : f32
+      tt.scan.return %1, %2 : f32, f32
+    }) : (tensor<2x4xf32>, tensor<2x4xf32>) -> (tensor<2x4xf32>, tensor<2x4xf32>)
+    tt.return %0#0, %0#1 : tensor<2x4xf32>, tensor<2x4xf32>
+  }
+}

--- a/test/Conversion/TritonArithToLinalg/generic_reduce_dynamic_shape.mlir
+++ b/test/Conversion/TritonArithToLinalg/generic_reduce_dynamic_shape.mlir
@@ -1,0 +1,19 @@
+// RUN: triton-shared-opt --triton-arith-to-linalg %s | FileCheck %s
+
+module {
+  tt.func public @dynamic_left_projection(%input: tensor<?x?xi32>) -> tensor<?xi32> {
+    %result = "tt.reduce"(%input) <{axis = 0 : i32}> ({
+    ^bb0(%accumulator: i32, %current: i32):
+      tt.reduce.return %accumulator : i32
+    }) : (tensor<?x?xi32>) -> tensor<?xi32>
+    tt.return %result : tensor<?xi32>
+  }
+}
+
+// CHECK-LABEL: func.func @dynamic_left_projection
+// CHECK: %[[RETAINED_DIM:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xi32>
+// CHECK: %[[FIRST:.*]] = tensor.extract_slice %{{.*}}[0, 0] [1, %[[RETAINED_DIM]]] [1, 1] : tensor<?x?xi32> to tensor<?xi32>
+// CHECK: %[[REDUCED_DIM:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xi32>
+// CHECK: %[[REST_SIZE:.*]] = arith.subi %[[REDUCED_DIM]], %{{.*}} : index
+// CHECK: %[[REST:.*]] = tensor.extract_slice %{{.*}}[1, 0] [%[[REST_SIZE]], %[[RETAINED_DIM]]] [1, 1] : tensor<?x?xi32> to tensor<?x?xi32>
+// CHECK: linalg.reduce ins(%[[REST]] : tensor<?x?xi32>) outs(%[[FIRST]] : tensor<?xi32>) dimensions = [0]

--- a/test/Conversion/TritonArithToLinalg/generic_reduce_operand_order.mlir
+++ b/test/Conversion/TritonArithToLinalg/generic_reduce_operand_order.mlir
@@ -1,0 +1,19 @@
+// RUN: triton-shared-opt --triton-arith-to-linalg %s | FileCheck %s
+
+module {
+  tt.func public @left_projection() -> i32 {
+    %input = arith.constant dense<[1, 2, 3, 4]> : tensor<4xi32>
+    %result = "tt.reduce"(%input) <{axis = 0 : i32}> ({
+    ^bb0(%accumulator: i32, %current: i32):
+      tt.reduce.return %accumulator : i32
+    }) : (tensor<4xi32>) -> i32
+    tt.return %result : i32
+  }
+}
+
+// CHECK-LABEL: func.func @left_projection
+// CHECK:         %[[REDUCED:.*]] = linalg.reduce
+// CHECK:           (%[[CURRENT:.*]]: i32, %[[ACCUMULATED:.*]]: i32) {
+// CHECK-NEXT:        linalg.yield %[[ACCUMULATED]] : i32
+// CHECK:         %[[RESULT:.*]] = tensor.extract %[[REDUCED]][] : tensor<i32>
+// CHECK:         return %[[RESULT]] : i32

--- a/test/Conversion/TritonArithToLinalg/reduce_extend_fp32_precision.mlir
+++ b/test/Conversion/TritonArithToLinalg/reduce_extend_fp32_precision.mlir
@@ -83,9 +83,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [32], strides: [1], offsets: [0], shape: [0], order: [] : <f16> to tensor<32x!tt.ptr<f16>>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<32x!tt.ptr<f16>>) -> tensor<32xf16>
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_2_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<32xf16>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK:           [[VAR_filled_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_2_]] : tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<32xf16>) outs([[VAR_filled_]] : tensor<f32>) dimensions = [0]
 // CHECK:             ([[in_:.+]]: f16, [[init_:.+]]: f32) {
 // CHECK:               [[VAR_13_:%.+]] = arith.extf [[in_]] : f16 to f32
 // CHECK:               [[VAR_14_:%.+]] = arith.addf [[VAR_13_]], [[init_]] : f32
@@ -123,9 +123,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [32], strides: [1], offsets: [0], shape: [0], order: [] : <f16> to tensor<32x!tt.ptr<f16>>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<32x!tt.ptr<f16>>) -> tensor<32xf16>
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_2_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<32xf16>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK:           [[VAR_filled_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_2_]] : tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<32xf16>) outs([[VAR_filled_]] : tensor<f32>) dimensions = [0]
 // CHECK:             ([[in_:.+]]: f16, [[init_:.+]]: f32) {
 // CHECK:               [[VAR_8_:%.+]] = arith.extf [[in_]] : f16 to f32
 // CHECK:               [[VAR_9_:%.+]] = arith.addf [[VAR_8_]], [[init_]] : f32
@@ -150,9 +150,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [32], strides: [1], offsets: [0], shape: [0], order: [] : <bf16> to tensor<32x!tt.ptr<bf16>>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<32x!tt.ptr<bf16>>) -> tensor<32xbf16>
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_2_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<32xbf16>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK:           [[VAR_filled_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_2_]] : tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<32xbf16>) outs([[VAR_filled_]] : tensor<f32>) dimensions = [0]
 // CHECK:             ([[in_:.+]]: bf16, [[init_:.+]]: f32) {
 // CHECK:               [[VAR_8_:%.+]] = arith.extf [[in_]] : bf16 to f32
 // CHECK:               [[VAR_9_:%.+]] = arith.addf [[VAR_8_]], [[init_]] : f32
@@ -177,9 +177,9 @@ module {
 // CHECK-DAG:       [[VAR_0_:%.+]] = tts.make_tptr [[PARAM_0_]] to sizes: [32], strides: [1], offsets: [0], shape: [0], order: [] : <f32> to tensor<32x!tt.ptr<f32>>
 // CHECK-DAG:       [[VAR_1_:%.+]] = "tts.load"([[VAR_0_]]) <{operandSegmentSizes = array<i32: 1, 0, 0>, static_mask_dims = array<i64>}> : (tensor<32x!tt.ptr<f32>>) -> tensor<32xf32>
 // CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_2_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<32xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_2_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK:           [[VAR_filled_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_2_]] : tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_1_]] : tensor<32xf32>) outs([[VAR_filled_]] : tensor<f32>) dimensions = [0]
 // CHECK:             ([[in_:.+]]: f32, [[init_:.+]]: f32) {
 // CHECK:               [[VAR_7_:%.+]] = arith.addf [[in_]], [[init_]] : f32
 // CHECK:               linalg.yield [[VAR_7_]] : f32

--- a/test/Conversion/TritonArithToLinalg/reducemax_32_256_bf16.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducemax_32_256_bf16.mlir
@@ -47,7 +47,7 @@ module {
 // CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<(d0, d1, d2) -> (0, d1, d2)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: !tt.ptr<bf16>, [[PARAM_1_:%.+]]: tensor<256x16x!tt.ptr<bf16>>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF80 : bf16
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<32xi32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -132,13 +132,20 @@ module {
 // CHECK:             linalg.yield [[VAR_29_6_]] : !tt.ptr<bf16>
 // CHECK:           } -> tensor<32x256x16x!tt.ptr<bf16>>
 // CHECK-DAG:       [[LOAD_VAR_25_MEM_:%.+]] = tt.load [[VAR_25_]] : tensor<32x256x16x!tt.ptr<bf16>>
-// CHECK-DAG:       [[VAR_27_:%.+]] = tensor.empty() : tensor<256x16xbf16>
-// CHECK:           [[VAR_28_:%.+]] = linalg.fill ins([[CST_0_]] : bf16) outs([[VAR_27_]] : tensor<256x16xbf16>) -> tensor<256x16xbf16>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[LOAD_VAR_25_MEM_]] : tensor<32x256x16xbf16>) outs([[VAR_28_]] : tensor<256x16xbf16>) dimensions = [0]
-// CHECK:             ([[in_]]: bf16, [[in_]]it: bf16) {
-// CHECK:               [[VAR_29_7_:%.+]] = arith.maximumf [[in_]], [[in_]]it : bf16
-// CHECK:               linalg.yield [[VAR_29_7_]] : bf16
+// CHECK-DAG:       [[VAR_27_:%.+]] = tensor.empty() : tensor<256x16xf32>
+// CHECK:           [[VAR_28_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_27_]] : tensor<256x16xf32>) -> tensor<256x16xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[LOAD_VAR_25_MEM_]] : tensor<32x256x16xbf16>) outs([[VAR_28_]] : tensor<256x16xf32>) dimensions = [0]
+// CHECK:             ([[in_]]: bf16, [[in_]]it: f32) {
+// CHECK:               [[EXTF_0:%.+]] = arith.extf [[in_]] : bf16 to f32
+// CHECK:               [[VAR_29_7_:%.+]] = arith.maximumf [[EXTF_0]], [[in_]]it : f32
+// CHECK:               linalg.yield [[VAR_29_7_]] : f32
 // CHECK:             }
-// CHECK:           tt.store [[PARAM_1_]], [[VAR_reduced_]] : tensor<256x16x!tt.ptr<bf16>>
+// CHECK:           [[VAR_30_:%.+]] = tensor.empty() : tensor<256x16xbf16>
+// CHECK:           [[VAR_31_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_reduced_]] : tensor<256x16xf32>) outs([[VAR_30_]] : tensor<256x16xbf16>) {
+// CHECK:           ^bb0([[in_]]: f32, [[out_]]: bf16):
+// CHECK:             [[TRUNCF_0:%.+]] = arith.truncf [[in_]] : f32 to bf16
+// CHECK:             linalg.yield [[TRUNCF_0]] : bf16
+// CHECK:           } -> tensor<256x16xbf16>
+// CHECK:           tt.store [[PARAM_1_]], [[VAR_31_]] : tensor<256x16x!tt.ptr<bf16>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonArithToLinalg/reducesum_512_256_bf16_axis0.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_512_256_bf16_axis0.mlir
@@ -36,7 +36,7 @@ module {
 // CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<(d0, d1) -> (0, d1)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: !tt.ptr<bf16>, [[PARAM_1_:%.+]]: !tt.ptr<bf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<512xi32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -92,13 +92,20 @@ module {
 // CHECK:             linalg.yield [[VAR_21_5_]] : !tt.ptr<bf16>
 // CHECK:           } -> tensor<256x!tt.ptr<bf16>>
 // CHECK-DAG:       [[LOAD_VAR_14_MEM_:%.+]] = tt.load [[VAR_14_]] : tensor<512x256x!tt.ptr<bf16>>
-// CHECK-DAG:       [[VAR_19_:%.+]] = tensor.empty() : tensor<256xbf16>
-// CHECK:           [[VAR_20_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_19_]] : tensor<256xbf16>) -> tensor<256xbf16>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[LOAD_VAR_14_MEM_]] : tensor<512x256xbf16>) outs([[VAR_20_]] : tensor<256xbf16>) dimensions = [0]
-// CHECK:             ([[in_]]: bf16, [[in_]]it: bf16) {
-// CHECK:               [[VAR_21_6_:%.+]] = arith.addf [[in_]], [[in_]]it : bf16
-// CHECK:               linalg.yield [[VAR_21_6_]] : bf16
+// CHECK-DAG:       [[VAR_19_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_20_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_19_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[LOAD_VAR_14_MEM_]] : tensor<512x256xbf16>) outs([[VAR_20_]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: bf16, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_21_6_:%.+]] = arith.extf [[in_]] : bf16 to f32
+// CHECK:               [[VAR_21_7_:%.+]] = arith.addf [[VAR_21_6_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_21_7_]] : f32
 // CHECK:             }
-// CHECK:           tt.store [[VAR_17_]], [[VAR_reduced_]] : tensor<256x!tt.ptr<bf16>>
+// CHECK:           [[VAR_21_8_:%.+]] = tensor.empty() : tensor<256xbf16>
+// CHECK:           [[VAR_21_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]] : tensor<256xf32>) outs([[VAR_21_8_]] : tensor<256xbf16>) {
+// CHECK:           ^bb0([[in_]]: f32, [[out_]]: bf16):
+// CHECK:             [[VAR_21_10_:%.+]] = arith.truncf [[in_]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_21_10_]] : bf16
+// CHECK:           } -> tensor<256xbf16>
+// CHECK:           tt.store [[VAR_17_]], [[VAR_21_9_]] : tensor<256x!tt.ptr<bf16>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonArithToLinalg/reducesum_512_256_bf16_axis1.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_512_256_bf16_axis1.mlir
@@ -36,7 +36,7 @@ module {
 // CHECK-DAG:   [[MAP_3_:#.+]] = affine_map<(d0, d1) -> (0, d1)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: !tt.ptr<bf16>, [[PARAM_1_:%.+]]: !tt.ptr<bf16>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<512xi32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -95,13 +95,20 @@ module {
 // CHECK-DAG:       [[VAR_19_:%.+]] = tensor.empty() : tensor<256x512xbf16>
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_transposed_:%.+]] = linalg.transpose ins([[LOAD_VAR_14_MEM_]] : tensor<512x256xbf16>) outs([[VAR_19_]] : tensor<256x512xbf16>) permutation = [1, 0]
-// CHECK-DAG:       [[VAR_20_:%.+]] = tensor.empty() : tensor<512xbf16>
-// CHECK:           [[VAR_21_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_20_]] : tensor<512xbf16>) -> tensor<512xbf16>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_transposed_]] : tensor<256x512xbf16>) outs([[VAR_21_]] : tensor<512xbf16>) dimensions = [0]
-// CHECK:             ([[in_]]: bf16, [[in_]]it: bf16) {
-// CHECK:               [[VAR_22_6_:%.+]] = arith.addf [[in_]], [[in_]]it : bf16
-// CHECK:               linalg.yield [[VAR_22_6_]] : bf16
+// CHECK-DAG:       [[VAR_20_:%.+]] = tensor.empty() : tensor<512xf32>
+// CHECK:           [[VAR_21_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_20_]] : tensor<512xf32>) -> tensor<512xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_transposed_]] : tensor<256x512xbf16>) outs([[VAR_21_]] : tensor<512xf32>) dimensions = [0]
+// CHECK:             ([[in_:%.+]]: bf16, [[init_:%.+]]: f32) {
+// CHECK:               [[VAR_22_6_:%.+]] = arith.extf [[in_]] : bf16 to f32
+// CHECK:               [[VAR_22_7_:%.+]] = arith.addf [[VAR_22_6_]], [[init_]] : f32
+// CHECK:               linalg.yield [[VAR_22_7_]] : f32
 // CHECK:             }
-// CHECK:           tt.store [[VAR_17_]], [[VAR_reduced_]] : tensor<512x!tt.ptr<bf16>>
+// CHECK:           [[VAR_22_8_:%.+]] = tensor.empty() : tensor<512xbf16>
+// CHECK:           [[VAR_22_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]] : tensor<512xf32>) outs([[VAR_22_8_]] : tensor<512xbf16>) {
+// CHECK:           ^bb0([[in_]]: f32, [[out_]]: bf16):
+// CHECK:             [[VAR_22_10_:%.+]] = arith.truncf [[in_]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_22_10_]] : bf16
+// CHECK:           } -> tensor<512xbf16>
+// CHECK:           tt.store [[VAR_17_]], [[VAR_22_9_]] : tensor<512x!tt.ptr<bf16>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonArithToLinalg/reducesum_middle_dim.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_middle_dim.mlir
@@ -47,7 +47,7 @@ module {
 // CHECK-DAG:   [[MAP_6_:#.+]] = affine_map<(d0, d1, d2) -> (0, d1, d2)>
 // CHECK-LABEL:  func.func @kernel
 // CHECK-SAME:   ([[PARAM_0_:%.+]]: !tt.ptr<bf16>, [[PARAM_1_:%.+]]: !tt.ptr<bf16>, [[PARAM_2_:%.+]]: tensor<32x16x!tt.ptr<bf16>>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
-// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : bf16
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
 // CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : i32
 // CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<32xi32>
 // CHECK-NOT: separator of consecutive DAGs
@@ -134,13 +134,20 @@ module {
 // CHECK-DAG:       [[LOAD_VAR_25_MEM_:%.+]] = tt.load [[VAR_25_]] : tensor<32x256x16x!tt.ptr<bf16>>
 // CHECK:           [[VAL_72:%.+]] = tensor.empty() : tensor<256x32x16xbf16>
 // CHECK:           [[VAL_73:%.+]] = linalg.transpose ins([[LOAD_VAR_25_MEM_]] : tensor<32x256x16xbf16>) outs([[VAL_72]] : tensor<256x32x16xbf16>) permutation = [1, 0, 2]
-// CHECK-DAG:       [[VAR_27_:%.+]] = tensor.empty() : tensor<32x16xbf16>
-// CHECK:           [[VAR_28_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : bf16) outs([[VAR_27_]] : tensor<32x16xbf16>) -> tensor<32x16xbf16>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAL_73]] : tensor<256x32x16xbf16>) outs([[VAR_28_]] : tensor<32x16xbf16>) dimensions = [0]
-// CHECK:             ([[in_]]: bf16, [[in_]]it: bf16) {
-// CHECK:               [[VAR_29_7_:%.+]] = arith.addf [[in_]], [[in_]]it : bf16
-// CHECK:               linalg.yield [[VAR_29_7_]] : bf16
+// CHECK-DAG:       [[VAR_27_:%.+]] = tensor.empty() : tensor<32x16xf32>
+// CHECK:           [[VAR_28_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_27_]] : tensor<32x16xf32>) -> tensor<32x16xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAL_73]] : tensor<256x32x16xbf16>) outs([[VAR_28_]] : tensor<32x16xf32>) dimensions = [0]
+// CHECK:             ([[in_]]: bf16, [[in_]]it: f32) {
+// CHECK:               [[EXTF_0:%.+]] = arith.extf [[in_]] : bf16 to f32
+// CHECK:               [[VAR_29_7_:%.+]] = arith.addf [[EXTF_0]], [[in_]]it : f32
+// CHECK:               linalg.yield [[VAR_29_7_]] : f32
 // CHECK:             }
-// CHECK:           tt.store [[PARAM_2_]], [[VAR_reduced_]] : tensor<32x16x!tt.ptr<bf16>>
+// CHECK:           [[VAR_30_:%.+]] = tensor.empty() : tensor<32x16xbf16>
+// CHECK:           [[VAR_31_:%.+]] = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins([[VAR_reduced_]] : tensor<32x16xf32>) outs([[VAR_30_]] : tensor<32x16xbf16>) {
+// CHECK:           ^bb0([[in_]]: f32, [[out_]]: bf16):
+// CHECK:             [[TRUNCF_0:%.+]] = arith.truncf [[in_]] : f32 to bf16
+// CHECK:             linalg.yield [[TRUNCF_0]] : bf16
+// CHECK:           } -> tensor<32x16xbf16>
+// CHECK:           tt.store [[PARAM_2_]], [[VAR_31_]] : tensor<32x16x!tt.ptr<bf16>>
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonArithToLinalg/reducesum_scalar.mlir
+++ b/test/Conversion/TritonArithToLinalg/reducesum_scalar.mlir
@@ -34,9 +34,9 @@ module {
 // CHECK:             linalg.yield [[VAR_8_1_]] : !tt.ptr<bf16>
 // CHECK:           } -> tensor<128x!tt.ptr<bf16>>
 // CHECK-DAG:       [[LOAD_VAR_4_MEM_:%.+]] = tt.load [[VAR_4_]] : tensor<128x!tt.ptr<bf16>>
-// CHECK-DAG:       [[VAR_6_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_6_]][] : tensor<f32>
-// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[LOAD_VAR_4_MEM_]] : tensor<128xbf16>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK-DAG:       [[VAR_6_:%.+]] = tensor.empty() : tensor<f32>
+// CHECK:           [[VAR_filled_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_6_]] : tensor<f32>) -> tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[LOAD_VAR_4_MEM_]] : tensor<128xbf16>) outs([[VAR_filled_]] : tensor<f32>) dimensions = [0]
 // CHECK:             ([[in_:%.*]]: bf16, [[init_:%.*]]: f32) {
 // CHECK:               [[VAR_8_2_:%.+]] = arith.extf [[in_]] : bf16 to f32
 // CHECK:               [[VAR_9_1_:%.+]] = arith.addf [[VAR_8_2_]], [[init_]] : f32

--- a/test/Conversion/TritonToLinalg/convert_addi_reduce.mlir
+++ b/test/Conversion/TritonToLinalg/convert_addi_reduce.mlir
@@ -18,8 +18,8 @@ module {
 // CHECK:           %[[VAL_7:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_8:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:           %[[VAL_9:.*]] = linalg.fill ins(%[[VAL_7]] : i32) outs(%[[VAL_8]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK:           %[[VAL_10:.*]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:           %[[VAL_11:.*]] = tensor.insert %[[VAL_7]] into %[[VAL_10]][] : tensor<i32>
+// CHECK:           %[[VAL_10:.*]] = tensor.empty() : tensor<i32>
+// CHECK:           %[[VAL_11:.*]] = linalg.fill ins(%[[VAL_7]] : i32) outs(%[[VAL_10]] : tensor<i32>) -> tensor<i32>
 // CHECK:           %[[VAL_12:.*]] = linalg.reduce ins(%[[VAL_9]] : tensor<4096xi32>) outs(%[[VAL_11]] : tensor<i32>) dimensions = [0]
 // CHECK:             (%[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i32) {
 // CHECK:               %[[VAL_15:.*]] = arith.addi %[[VAL_13]], %[[VAL_14]] : i32

--- a/test/Conversion/TritonToLinalg/convert_argmin_argmax_2d.mlir
+++ b/test/Conversion/TritonToLinalg/convert_argmin_argmax_2d.mlir
@@ -79,11 +79,15 @@ module {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
-// CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<4xf32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_7_]] : tensor<4xf32>) -> tensor<4xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<4xi32>
-// CHECK:           [[VAR_10_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_9_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_6_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_8_]], [[VAR_10_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
+// CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<4x4xf32>
+// CHECK:           [[TRANSPOSE_0:%.+]] = linalg.transpose ins([[VAR_4_]] : tensor<4x4xf32>) outs([[VAR_7_]] : tensor<4x4xf32>) permutation = [1, 0]
+// CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<4x4xi32>
+// CHECK:           [[TRANSPOSE_1:%.+]] = linalg.transpose ins([[VAR_6_]] : tensor<4x4xi32>) outs([[VAR_8_]] : tensor<4x4xi32>) permutation = [1, 0]
+// CHECK:           [[VAR_9_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_9_]] : tensor<4xf32>) -> tensor<4xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<4xi32>
+// CHECK:           [[VAR_12_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_11_]] : tensor<4xi32>) -> tensor<4xi32>
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[TRANSPOSE_0]], [[TRANSPOSE_1]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_10_]], [[VAR_12_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [0]
 // CHECK:             ([[in_:.+]]: f32, [[in_1_:.+]]: i32, [[init:.+]]: f32, [[init_2:.+]]: i32) {
 // CHECK-DAG:           [[VAR_13_1_:%.+]] = arith.cmpf oeq, [[in_]], [[init]] : f32
 // CHECK-DAG:           [[VAR_14_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2]] : i32
@@ -96,13 +100,13 @@ module {
 // CHECK:               linalg.yield [[VAR_18_]], [[VAR_19_]] : f32, i32
 // CHECK:             }
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1]>>
-// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<4xf32>
-// CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_11_]] : tensor<4xf32>) {
+// CHECK-DAG:       [[VAR_13_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_13_]] : tensor<4xf32>) {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: f32):
 // CHECK:             [[VAR_13_2_:%.+]] = arith.sitofp [[in_]] : i32 to f32
 // CHECK:             linalg.yield [[VAR_13_2_]] : f32
 // CHECK:           } -> tensor<4xf32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_0_]]
+// CHECK:           bufferization.materialize_in_destination [[VAR_14_]] in writable [[VAR_reinterpret_cast_0_]]
 // CHECK:           return
 // CHECK:         }
 
@@ -187,11 +191,15 @@ module {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: i32):
 // CHECK:             linalg.yield [[in_]] : i32
 // CHECK:           } -> tensor<4x4xi32>
-// CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<4xf32>
-// CHECK-DAG:       [[VAR_8_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_7_]] : tensor<4xf32>) -> tensor<4xf32>
-// CHECK-DAG:       [[VAR_9_:%.+]] = tensor.empty() : tensor<4xi32>
-// CHECK:           [[VAR_10_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_9_]] : tensor<4xi32>) -> tensor<4xi32>
-// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[VAR_4_]], [[VAR_6_]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_8_]], [[VAR_10_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [1]
+// CHECK:           [[VAR_7_:%.+]] = tensor.empty() : tensor<4x4xf32>
+// CHECK:           [[TRANSPOSE_0:%.+]] = linalg.transpose ins([[VAR_4_]] : tensor<4x4xf32>) outs([[VAR_7_]] : tensor<4x4xf32>) permutation = [1, 0]
+// CHECK:           [[VAR_8_:%.+]] = tensor.empty() : tensor<4x4xi32>
+// CHECK:           [[TRANSPOSE_1:%.+]] = linalg.transpose ins([[VAR_6_]] : tensor<4x4xi32>) outs([[VAR_8_]] : tensor<4x4xi32>) permutation = [1, 0]
+// CHECK:           [[VAR_9_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = linalg.fill ins([[CST_0_]] : f32) outs([[VAR_9_]] : tensor<4xf32>) -> tensor<4xf32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<4xi32>
+// CHECK:           [[VAR_12_:%.+]] = linalg.fill ins([[CST_minus_1_]] : i32) outs([[VAR_11_]] : tensor<4xi32>) -> tensor<4xi32>
+// CHECK:           [[VAR_reduced_:%.+]]:2 = linalg.reduce ins([[TRANSPOSE_0]], [[TRANSPOSE_1]] : tensor<4x4xf32>, tensor<4x4xi32>) outs([[VAR_10_]], [[VAR_12_]] : tensor<4xf32>, tensor<4xi32>) dimensions = [0]
 // CHECK:             ([[in_:.+]]: f32, [[in_1_:.+]]: i32, [[init:.+]]: f32, [[init_2:.+]]: i32) {
 // CHECK-DAG:           [[VAR_13_1_:%.+]] = arith.cmpf oeq, [[in_]], [[init]] : f32
 // CHECK-DAG:           [[VAR_14_1_:%.+]] = arith.cmpi slt, [[in_1_]], [[init_2]] : i32
@@ -204,12 +212,12 @@ module {
 // CHECK:               linalg.yield [[VAR_18_]], [[VAR_19_]] : f32, i32
 // CHECK:             }
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: [0], sizes: [4], strides: [1] : memref<*xf32> to memref<4xf32, strided<[1]>>
-// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<4xf32>
-// CHECK:           [[VAR_12_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_11_]] : tensor<4xf32>) {
+// CHECK-DAG:       [[VAR_13_:%.+]] = tensor.empty() : tensor<4xf32>
+// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_reduced_]]#1 : tensor<4xi32>) outs([[VAR_13_]] : tensor<4xf32>) {
 // CHECK:           ^bb0([[in_:.+]]: i32, [[out_:.+]]: f32):
 // CHECK:             [[VAR_13_2_:%.+]] = arith.sitofp [[in_]] : i32 to f32
 // CHECK:             linalg.yield [[VAR_13_2_]] : f32
 // CHECK:           } -> tensor<4xf32>
-// CHECK:           bufferization.materialize_in_destination [[VAR_12_]] in writable [[VAR_reinterpret_cast_0_]]
+// CHECK:           bufferization.materialize_in_destination [[VAR_14_]] in writable [[VAR_reinterpret_cast_0_]]
 // CHECK:           return
 // CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_minmax_fp_reduce.mlir
+++ b/test/Conversion/TritonToLinalg/convert_minmax_fp_reduce.mlir
@@ -19,15 +19,15 @@ module {
 // CHECK:  %[[CST_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<4096xf32>
 // CHECK:  %[[VAL_1:.*]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[VAL_0]] : tensor<4096xf32>) -> tensor<4096xf32>
-// CHECK:  %[[VAL_2:.*]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:  %[[VAL_3:.*]] = tensor.insert %[[CST]] into %[[VAL_2]][] : tensor<f32>
+// CHECK:  %[[VAL_2:.*]] = tensor.empty() : tensor<f32>
+// CHECK:  %[[VAL_3:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[VAL_2]] : tensor<f32>) -> tensor<f32>
 // CHECK:  %[[VAL_4:.*]] = linalg.reduce ins(%[[VAL_1]] : tensor<4096xf32>) outs(%[[VAL_3]] : tensor<f32>) dimensions = [0]
 // CHECK:    (%in: f32, %init: f32) {
 // CHECK:      %[[VAL_5:.*]] = arith.maxnumf %in, %init : f32
 // CHECK:      linalg.yield %[[VAL_5]] : f32
 // CHECK:    }
 // CHECK:  %[[VAL_6:.*]] = tensor.extract %[[VAL_4]][] : tensor<f32>
-// CHECK:  %[[VAL_7:.*]] = memref.[[VAL_7]] %arg0 to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1]>>
+// CHECK:  %[[VAL_7:.*]] = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1]>>
 // CHECK:  affine.store %[[VAL_6]], %[[VAL_7]][0] : memref<1xf32, strided<[1]>>
 // CHECK:  return
 // CHECK:}
@@ -54,15 +54,15 @@ module {
 // CHECK:  %[[CST_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<4096xf32>
 // CHECK:  %[[VAL_1:.*]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[VAL_0]] : tensor<4096xf32>) -> tensor<4096xf32>
-// CHECK:  %[[VAL_2:.*]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:  %[[VAL_3:.*]] = tensor.insert %[[CST]] into %[[VAL_2]][] : tensor<f32>
+// CHECK:  %[[VAL_2:.*]] = tensor.empty() : tensor<f32>
+// CHECK:  %[[VAL_3:.*]] = linalg.fill ins(%[[CST]] : f32) outs(%[[VAL_2]] : tensor<f32>) -> tensor<f32>
 // CHECK:  %[[VAL_4:.*]] = linalg.reduce ins(%[[VAL_1]] : tensor<4096xf32>) outs(%[[VAL_3]] : tensor<f32>) dimensions = [0]
 // CHECK:    (%in: f32, %init: f32) {
 // CHECK:      %[[VAL_5:.*]] = arith.minnumf %in, %init : f32
 // CHECK:      linalg.yield %[[VAL_5]] : f32
 // CHECK:    }
 // CHECK:  %[[VAL_6:.*]] = tensor.extract %[[VAL_4]][] : tensor<f32>
-// CHECK:  %[[VAL_7:.*]] = memref.[[VAL_7]] %arg0 to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1]>>
+// CHECK:  %[[VAL_7:.*]] = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1]>>
 // CHECK:  affine.store %[[VAL_6]], %[[VAL_7]][0] : memref<1xf32, strided<[1]>>
 // CHECK:  return
 // CHECK:}

--- a/test/Conversion/TritonToLinalg/convert_minmax_reduce.mlir
+++ b/test/Conversion/TritonToLinalg/convert_minmax_reduce.mlir
@@ -16,8 +16,8 @@ module {
 // CHECK:  func.func @minmax_sgt(%[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
 // CHECK:    %[[VAL_7:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:    %[[VAL_8:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_7]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK:    %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:    %[[VAL_10:.*]] = tensor.insert %c-2147483648{{.*}} into %[[VAL_9]][] : tensor<i32>
+// CHECK:    %[[VAL_9:.*]] = tensor.empty() : tensor<i32>
+// CHECK:    %[[VAL_10:.*]] = linalg.fill ins(%c-2147483648{{.*}} : i32) outs(%[[VAL_9]] : tensor<i32>) -> tensor<i32>
 // CHECK:    %[[VAL_11:.*]] = linalg.reduce ins(%[[VAL_8]] : tensor<4096xi32>) outs(%[[VAL_10]] : tensor<i32>) dimensions = [0]
 // CHECK:      (%in: i32, %init: i32) {
 // CHECK:        %[[VAL_12:.*]] = arith.maxsi %in, %init : i32
@@ -48,8 +48,8 @@ module {
 // CHECK:  func.func @minmax_ugt(%[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
 // CHECK:    %[[VAL_7:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:    %[[VAL_8:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_7]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK:    %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:    %[[VAL_10:.*]] = tensor.insert %c0{{.*}} into %[[VAL_9]][] : tensor<i32>
+// CHECK:    %[[VAL_9:.*]] = tensor.empty() : tensor<i32>
+// CHECK:    %[[VAL_10:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_9]] : tensor<i32>) -> tensor<i32>
 // CHECK:    %[[VAL_11:.*]] = linalg.reduce ins(%[[VAL_8]] : tensor<4096xi32>) outs(%[[VAL_10]] : tensor<i32>) dimensions = [0]
 // CHECK:      (%in: i32, %init: i32) {
 // CHECK:        %[[VAL_12:.*]] = arith.maxui %in, %init : i32
@@ -80,8 +80,8 @@ module {
 // CHECK:  func.func @minmax_slt(%[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
 // CHECK:    %[[VAL_7:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:    %[[VAL_8:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_7]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK:    %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:    %[[VAL_10:.*]] = tensor.insert %c2147483647{{.*}} into %[[VAL_9]][] : tensor<i32>
+// CHECK:    %[[VAL_9:.*]] = tensor.empty() : tensor<i32>
+// CHECK:    %[[VAL_10:.*]] = linalg.fill ins(%c2147483647{{.*}} : i32) outs(%[[VAL_9]] : tensor<i32>) -> tensor<i32>
 // CHECK:    %[[VAL_11:.*]] = linalg.reduce ins(%[[VAL_8]] : tensor<4096xi32>) outs(%[[VAL_10]] : tensor<i32>) dimensions = [0]
 // CHECK:      (%in: i32, %init: i32) {
 // CHECK:        %[[VAL_12:.*]] = arith.minsi %in, %init : i32
@@ -112,8 +112,8 @@ module {
 // CHECK:  func.func @minmax_ult(%[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
 // CHECK:    %[[VAL_7:.*]] = tensor.empty() : tensor<4096xi32>
 // CHECK:    %[[VAL_8:.*]] = linalg.fill ins(%c0{{.*}} : i32) outs(%[[VAL_7]] : tensor<4096xi32>) -> tensor<4096xi32>
-// CHECK:    %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<i32>
-// CHECK:    %[[VAL_10:.*]] = tensor.insert %c-1{{.*}} into %[[VAL_9]][] : tensor<i32>
+// CHECK:    %[[VAL_9:.*]] = tensor.empty() : tensor<i32>
+// CHECK:    %[[VAL_10:.*]] = linalg.fill ins(%c-1{{.*}} : i32) outs(%[[VAL_9]] : tensor<i32>) -> tensor<i32>
 // CHECK:    %[[VAL_11:.*]] = linalg.reduce ins(%[[VAL_8]] : tensor<4096xi32>) outs(%[[VAL_10]] : tensor<i32>) dimensions = [0]
 // CHECK:      (%in: i32, %init: i32) {
 // CHECK:        %[[VAL_12:.*]] = arith.minui %in, %init : i32

--- a/test/Conversion/TritonToLinalg/cumsum.mlir
+++ b/test/Conversion/TritonToLinalg/cumsum.mlir
@@ -52,13 +52,20 @@ module {
 // CHECK:           memref.copy [[VAR_reinterpret_cast_]], [[RES_]] : memref<4096xf32, strided<[1], offset: ?>> to memref<4096xf32>
 // CHECK-DAG:       [[VAR_2_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<4096xf32>
 // CHECK-DAG:       [[VAR_3_:%.+]] = tensor.empty() : tensor<4096xf32>
-// CHECK-NOT: separator of consecutive DAGs
-// CHECK-DAG:       [[VAR_4_:%.+]] = ttx.cumsum {axis = 0 : ui32, operandSegmentSizes = array<i32: 1, 1>} ins([[VAR_2_]] : tensor<4096xf32>) outs([[VAR_3_]] : tensor<4096xf32>) -> tensor<4096xf32>
+// CHECK:           [[EXTRACT_0:%.+]] = tensor.extract [[VAR_2_]][%c0] : tensor<4096xf32>
+// CHECK:           [[INSERT_0:%.+]] = tensor.insert [[EXTRACT_0]] into [[VAR_3_]][%c0] : tensor<4096xf32>
+// CHECK:           [[SCAN_RES:%.+]]:2 = scf.for
+// CHECK-SAME:        iter_args([[ACC:%.+]] = [[EXTRACT_0]], [[OUT:%.+]] = [[INSERT_0]]) -> (f32, tensor<4096xf32>) {
+// CHECK:             [[CUR:%.+]] = tensor.extract [[VAR_2_]]
+// CHECK:             [[NEXT:%.+]] = arith.addf [[ACC]], [[CUR]] : f32
+// CHECK:             [[INSERT:%.+]] = tensor.insert [[NEXT]] into [[OUT]]
+// CHECK:             scf.yield [[NEXT]], [[INSERT]] : f32, tensor<4096xf32>
+// CHECK:           }
 // CHECK-DAG:       [[VAR_5_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
 // CHECK-NOT: separator of consecutive DAGs
 // CHECK-DAG:       [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_5_]]{{.}}, sizes: [4096], strides: [1] : memref<*xi32> to memref<4096xi32, strided<[1], offset: ?>>
 // CHECK-DAG:       [[VAR_6_:%.+]] = tensor.empty() : tensor<4096xi32>
-// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_4_]] : tensor<4096xf32>) outs([[VAR_6_]] : tensor<4096xi32>) {
+// CHECK:           [[VAR_7_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[SCAN_RES]]#1 : tensor<4096xf32>) outs([[VAR_6_]] : tensor<4096xi32>) {
 // CHECK:           ^bb0([[in_:.+]]: f32, [[out_:.+]]: i32):
 // CHECK:             [[VAR_8_:%.+]] = arith.fptosi [[in_]] : f32 to i32
 // CHECK:             linalg.yield [[VAR_8_]] : i32

--- a/test/Conversion/TritonToLinalg/reducemax_32_256_bf16.mlir
+++ b/test/Conversion/TritonToLinalg/reducemax_32_256_bf16.mlir
@@ -18,19 +18,26 @@
 // CHECK-SAME:                      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0xFF80 : bf16
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0xFF800000 : f32
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [32, 256, 16], strides: [256, 1, 1] : memref<*xbf16> to memref<32x256x16xbf16, strided<[256, 1, 1]>>
 // CHECK:           %[[ALLOC_0:.*]] = memref.alloc() : memref<32x256x16xbf16>
 // CHECK:           memref.copy %[[REINTERPRET_CAST_0]], %[[ALLOC_0]] : memref<32x256x16xbf16, strided<[256, 1, 1]>> to memref<32x256x16xbf16>
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<32x256x16xbf16> to tensor<32x256x16xbf16>
-// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256x16xbf16>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : bf16) outs(%[[EMPTY_0]] : tensor<256x16xbf16>) -> tensor<256x16xbf16>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<32x256x16xbf16>) outs(%[[FILL_0]] : tensor<256x16xbf16>) dimensions = [0]
-// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: bf16) {
-// CHECK:               %[[MAXIMUMF_0:.*]] = arith.maximumf %[[VAL_0]], %[[VAL_1]] : bf16
-// CHECK:               linalg.yield %[[MAXIMUMF_0]] : bf16
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256x16xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_0]] : tensor<256x16xf32>) -> tensor<256x16xf32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<32x256x16xbf16>) outs(%[[FILL_0]] : tensor<256x16xf32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: f32) {
+// CHECK:               %[[EXTF_0:.*]] = arith.extf %[[VAL_0]] : bf16 to f32
+// CHECK:               %[[MAXIMUMF_0:.*]] = arith.maximumf %[[EXTF_0]], %[[VAL_1]] : f32
+// CHECK:               linalg.yield %[[MAXIMUMF_0]] : f32
 // CHECK:             }
-// CHECK:           bufferization.materialize_in_destination %[[REDUCE_0]] in writable %[[ARG1]] : (tensor<256x16xbf16>, memref<256x16xbf16>) -> ()
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<256x16xbf16>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[REDUCE_0]] : tensor<256x16xf32>) outs(%[[EMPTY_1]] : tensor<256x16xbf16>) {
+// CHECK:           ^bb0(%[[IN:.*]]: f32, %[[OUT:.*]]: bf16):
+// CHECK:             %[[TRUNCF_0:.*]] = arith.truncf %[[IN]] : f32 to bf16
+// CHECK:             linalg.yield %[[TRUNCF_0]] : bf16
+// CHECK:           } -> tensor<256x16xbf16>
+// CHECK:           bufferization.materialize_in_destination %[[GENERIC_0]] in writable %[[ARG1]] : (tensor<256x16xbf16>, memref<256x16xbf16>) -> ()
 // CHECK:           return
 // CHECK:         }
 module {

--- a/test/Conversion/TritonToLinalg/reducesum_512_256_bf16_axis0.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_512_256_bf16_axis0.mlir
@@ -18,20 +18,27 @@
 // CHECK-SAME:                      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [512, 256], strides: [256, 1] : memref<*xbf16> to memref<512x256xbf16, strided<[256, 1]>>
 // CHECK:           %[[REINTERPRET_CAST_1:.*]] = memref.reinterpret_cast %[[ARG1]] to offset: [0], sizes: [256], strides: [1] : memref<*xbf16> to memref<256xbf16, strided<[1]>>
 // CHECK:           %[[ALLOC_0:.*]] = memref.alloc() : memref<512x256xbf16>
 // CHECK:           memref.copy %[[REINTERPRET_CAST_0]], %[[ALLOC_0]] : memref<512x256xbf16, strided<[256, 1]>> to memref<512x256xbf16>
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<512x256xbf16> to tensor<512x256xbf16>
-// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256xbf16>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : bf16) outs(%[[EMPTY_0]] : tensor<256xbf16>) -> tensor<256xbf16>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<512x256xbf16>) outs(%[[FILL_0]] : tensor<256xbf16>) dimensions = [0]
-// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: bf16) {
-// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : bf16
-// CHECK:               linalg.yield %[[ADDF_0]] : bf16
+// CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_0]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TO_TENSOR_0]] : tensor<512x256xbf16>) outs(%[[FILL_0]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: f32) {
+// CHECK:               %[[EXTF_0:.*]] = arith.extf %[[VAL_0]] : bf16 to f32
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[EXTF_0]], %[[VAL_1]] : f32
+// CHECK:               linalg.yield %[[ADDF_0]] : f32
 // CHECK:             }
-// CHECK:           bufferization.materialize_in_destination %[[REDUCE_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<256xbf16>, memref<256xbf16, strided<[1]>>) -> ()
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<256xbf16>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[REDUCE_0]] : tensor<256xf32>) outs(%[[EMPTY_1]] : tensor<256xbf16>) {
+// CHECK:           ^bb0(%[[IN:.*]]: f32, %[[OUT:.*]]: bf16):
+// CHECK:             %[[TRUNCF_0:.*]] = arith.truncf %[[IN]] : f32 to bf16
+// CHECK:             linalg.yield %[[TRUNCF_0]] : bf16
+// CHECK:           } -> tensor<256xbf16>
+// CHECK:           bufferization.materialize_in_destination %[[GENERIC_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<256xbf16>, memref<256xbf16, strided<[1]>>) -> ()
 // CHECK:           return
 // CHECK:         }
 module {

--- a/test/Conversion/TritonToLinalg/reducesum_512_256_bf16_axis1.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_512_256_bf16_axis1.mlir
@@ -18,7 +18,7 @@
 // CHECK-SAME:                      %[[ARG5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [512, 256], strides: [256, 1] : memref<*xbf16> to memref<512x256xbf16, strided<[256, 1]>>
 // CHECK:           %[[REINTERPRET_CAST_1:.*]] = memref.reinterpret_cast %[[ARG1]] to offset: [0], sizes: [512], strides: [1] : memref<*xbf16> to memref<512xbf16, strided<[1]>>
 // CHECK:           %[[ALLOC_0:.*]] = memref.alloc() : memref<512x256xbf16>
@@ -26,14 +26,21 @@
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<512x256xbf16> to tensor<512x256xbf16>
 // CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256x512xbf16>
 // CHECK:           %[[TRANSPOSE_0:.*]] = linalg.transpose ins(%[[TO_TENSOR_0]] : tensor<512x256xbf16>) outs(%[[EMPTY_0]] : tensor<256x512xbf16>) permutation = [1, 0]
-// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<512xbf16>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : bf16) outs(%[[EMPTY_1]] : tensor<512xbf16>) -> tensor<512xbf16>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TRANSPOSE_0]] : tensor<256x512xbf16>) outs(%[[FILL_0]] : tensor<512xbf16>) dimensions = [0]
-// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: bf16) {
-// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : bf16
-// CHECK:               linalg.yield %[[ADDF_0]] : bf16
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<512xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_1]] : tensor<512xf32>) -> tensor<512xf32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TRANSPOSE_0]] : tensor<256x512xbf16>) outs(%[[FILL_0]] : tensor<512xf32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: f32) {
+// CHECK:               %[[EXTF_0:.*]] = arith.extf %[[VAL_0]] : bf16 to f32
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[EXTF_0]], %[[VAL_1]] : f32
+// CHECK:               linalg.yield %[[ADDF_0]] : f32
 // CHECK:             }
-// CHECK:           bufferization.materialize_in_destination %[[REDUCE_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<512xbf16>, memref<512xbf16, strided<[1]>>) -> ()
+// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<512xbf16>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[REDUCE_0]] : tensor<512xf32>) outs(%[[EMPTY_2]] : tensor<512xbf16>) {
+// CHECK:           ^bb0(%[[IN:.*]]: f32, %[[OUT:.*]]: bf16):
+// CHECK:             %[[TRUNCF_0:.*]] = arith.truncf %[[IN]] : f32 to bf16
+// CHECK:             linalg.yield %[[TRUNCF_0]] : bf16
+// CHECK:           } -> tensor<512xbf16>
+// CHECK:           bufferization.materialize_in_destination %[[GENERIC_0]] in writable %[[REINTERPRET_CAST_1]] : (tensor<512xbf16>, memref<512xbf16, strided<[1]>>) -> ()
 // CHECK:           return
 // CHECK:         }
 module {

--- a/test/Conversion/TritonToLinalg/reducesum_middle_dim.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_middle_dim.mlir
@@ -19,21 +19,28 @@
 // CHECK-SAME:                      %[[ARG6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                      %[[ARG8:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32) {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ARG0]] to offset: [0], sizes: [32, 256, 16], strides: [256, 1, 1] : memref<*xbf16> to memref<32x256x16xbf16, strided<[256, 1, 1]>>
 // CHECK:           %[[ALLOC_0:.*]] = memref.alloc() : memref<32x256x16xbf16>
 // CHECK:           memref.copy %[[REINTERPRET_CAST_0]], %[[ALLOC_0]] : memref<32x256x16xbf16, strided<[256, 1, 1]>> to memref<32x256x16xbf16>
 // CHECK:           %[[TO_TENSOR_0:.*]] = bufferization.to_tensor %[[ALLOC_0]] restrict writable : memref<32x256x16xbf16> to tensor<32x256x16xbf16>
 // CHECK:           %[[EMPTY_0:.*]] = tensor.empty() : tensor<256x32x16xbf16>
 // CHECK:           %[[TRANSPOSE_0:.*]] = linalg.transpose ins(%[[TO_TENSOR_0]] : tensor<32x256x16xbf16>) outs(%[[EMPTY_0]] : tensor<256x32x16xbf16>) permutation = [1, 0, 2]
-// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<32x16xbf16>
-// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : bf16) outs(%[[EMPTY_1]] : tensor<32x16xbf16>) -> tensor<32x16xbf16>
-// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TRANSPOSE_0]] : tensor<256x32x16xbf16>) outs(%[[FILL_0]] : tensor<32x16xbf16>) dimensions = [0]
-// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: bf16) {
-// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : bf16
-// CHECK:               linalg.yield %[[ADDF_0]] : bf16
+// CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<32x16xf32>
+// CHECK:           %[[FILL_0:.*]] = linalg.fill ins(%[[CONSTANT_0]] : f32) outs(%[[EMPTY_1]] : tensor<32x16xf32>) -> tensor<32x16xf32>
+// CHECK:           %[[REDUCE_0:.*]] = linalg.reduce ins(%[[TRANSPOSE_0]] : tensor<256x32x16xbf16>) outs(%[[FILL_0]] : tensor<32x16xf32>) dimensions = [0]
+// CHECK:             (%[[VAL_0:.*]]: bf16, %[[VAL_1:.*]]: f32) {
+// CHECK:               %[[EXTF_0:.*]] = arith.extf %[[VAL_0]] : bf16 to f32
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[EXTF_0]], %[[VAL_1]] : f32
+// CHECK:               linalg.yield %[[ADDF_0]] : f32
 // CHECK:             }
-// CHECK:           bufferization.materialize_in_destination %[[REDUCE_0]] in writable %[[ARG2]] : (tensor<32x16xbf16>, memref<32x16xbf16>) -> ()
+// CHECK:           %[[EMPTY_2:.*]] = tensor.empty() : tensor<32x16xbf16>
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[REDUCE_0]] : tensor<32x16xf32>) outs(%[[EMPTY_2]] : tensor<32x16xbf16>) {
+// CHECK:           ^bb0(%[[IN:.*]]: f32, %[[OUT:.*]]: bf16):
+// CHECK:             %[[TRUNCF_0:.*]] = arith.truncf %[[IN]] : f32 to bf16
+// CHECK:             linalg.yield %[[TRUNCF_0]] : bf16
+// CHECK:           } -> tensor<32x16xbf16>
+// CHECK:           bufferization.materialize_in_destination %[[GENERIC_0]] in writable %[[ARG2]] : (tensor<32x16xbf16>, memref<32x16xbf16>) -> ()
 // CHECK:           return
 // CHECK:         }
 module {

--- a/test/Conversion/TritonToLinalg/reducesum_scalar.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_scalar.mlir
@@ -22,8 +22,8 @@ module {
 // CHECK:           %[[VAL_7:.*]] = memref.alloc() : memref<128xbf16>
 // CHECK:           memref.copy %[[VAL_6]], %[[VAL_7]] : memref<128xbf16, strided<[1]>> to memref<128xbf16>
 // CHECK:           %[[VAL_8:.*]] = bufferization.to_tensor %[[VAL_7]] restrict writable : memref<128xbf16>
-// CHECK:           %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<f32>
-// CHECK:           %[[VAL_10:.*]] = tensor.insert %[[VAL_5]] into %[[VAL_9]][] : tensor<f32>
+// CHECK:           %[[VAL_9:.*]] = tensor.empty() : tensor<f32>
+// CHECK:           %[[VAL_10:.*]] = linalg.fill ins(%[[VAL_5]] : f32) outs(%[[VAL_9]] : tensor<f32>) -> tensor<f32>
 // CHECK:           %[[VAL_11:.*]] = linalg.reduce ins(%[[VAL_8]] : tensor<128xbf16>) outs(%[[VAL_10]] : tensor<f32>) dimensions = [0]
 // CHECK:             (%[[VAL_12:.*]]: bf16, %[[VAL_13:.*]]: f32) {
 // CHECK:               %[[VAL_14:.*]] = arith.extf %[[VAL_12]] : bf16 to f32

--- a/test/Conversion/TritonToLinalg/use_dot_opc.mlir
+++ b/test/Conversion/TritonToLinalg/use_dot_opc.mlir
@@ -35,7 +35,12 @@
 // CHECK:           %[[EMPTY_1:.*]] = tensor.empty() : tensor<128x256xbf16>
 // CHECK:           %[[FILL_1:.*]] = linalg.fill ins(%[[CONSTANT_0]] : bf16) outs(%[[EMPTY_1]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
 // CHECK:           %[[MATMUL_0:.*]] = linalg.matmul ins(%[[TO_TENSOR_0]], %[[TO_TENSOR_1]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs(%[[FILL_1]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
-// CHECK:           bufferization.materialize_in_destination %[[MATMUL_0]] in writable %[[CAST_0]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
+// CHECK:           %[[GENERIC_0:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[FILL_0]], %[[MATMUL_0]] : tensor<128x256xbf16>, tensor<128x256xbf16>) outs(%[[FILL_0]] : tensor<128x256xbf16>) {
+// CHECK:           ^bb0(%[[IN0:.*]]: bf16, %[[IN1:.*]]: bf16, %[[OUT:.*]]: bf16):
+// CHECK:             %[[ADDF_0:.*]] = arith.addf %[[IN0]], %[[IN1]] : bf16
+// CHECK:             linalg.yield %[[ADDF_0]] : bf16
+// CHECK:           } -> tensor<128x256xbf16>
+// CHECK:           bufferization.materialize_in_destination %[[GENERIC_0]] in writable %[[CAST_0]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
 // CHECK:           bufferization.materialize_in_destination %[[FILL_0]] in writable %[[CAST_0]] : (tensor<128x256xbf16>, memref<128x256xbf16, strided<[?, 1]>>) -> ()
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
  ## Summary

  Fix and generalize TritonArith-to-Linalg lowering for concatenation, join, matmul, reductions, argmin/argmax, and scans.

  The previous lowering relied on assumptions that only held for simple, single-result reductions and a narrow `ttx.cumsum` path. This caused incorrect operand ordering, incomplete precision promotion, fragile shape handling, and insufficient scan coverage.

  ## Problems addressed

  - Generic reductions could assume an incorrect operand order or only support a restricted reduction body.
  - Dynamic-shape reductions did not have a robust way to construct the initial
    slice and remaining reduction input.
  - FP16/BF16 reduction and matmul paths did not consistently promote operands to the accumulator type before computation.
  - Scan lowering was specialized around cumsum rather than general `tt.scan`, leaving reverse, rank-2, and multi-result cases unsupported.
  - `cat` and `join` did not fully validate input structure and could construct fragile slice offsets.

  ## Changes

  - Update `CatConverter` and `JoinConverter`:
    - use adapted operands;
    - reject empty or invalid input sets;
    - construct `tensor.concat` with the result type;
    - require exactly two inputs for join and use rank-derived slice placement.

  - Correct floating-point accumulation behavior:
    - promote matmul operands to the accumulator type when needed;
    - extend the FP32-promotion policy from `addf` to `mulf`, `maximumf`, and
      `minimumf`;
    - preserve fast-math attributes while promoting reduction elements.

  - Rework generic reduction lowering:
    - distinguish simple reductions from general reduction bodies;
    - support multiple operands and results;
    - use `linalg.fill` for simple reduction initialization;
    - use `tensor.extract_slice` for general reduction initialization;
    - construct dynamic offsets and sizes with `tensor.dim` and `arith.subi`;
    - clone the original reduction body so operand ordering and multi-result
      semantics are preserved.

  - Generalize scan lowering:
    - lower `tt.scan` rather than only the former cumsum special case;
    - support forward and reverse scans;
    - support rank-1 and rank-2 inputs;
    - support multiple scan inputs and results;
    - generate `scf.for` loops and clone the scan body.

  - Make argmin/argmax transpose behavior explicitly controlled by the
    `transposeReduceToRank0` option.

  ## Regression coverage

  New tests:

  - `test/Conversion/TritonArithToLinalg/generic_reduce_dynamic_shape.mlir`
    verifies dynamic-shape reduction initialization and sliced input formation.

  - `test/Conversion/TritonArithToLinalg/generic_reduce_operand_order.mlir`
    verifies that the reduction body receives current and accumulated values in
    the correct order.

  Updated tests cover:

  - BF16 reduce-sum and reduce-max precision promotion and truncation;
  - floating-point min/max reductions;
  - scalar and middle-dimension reductions;
  - argmin/argmax lowering;
  - dot/matmul accumulator conversion;
  - forward/reverse rank-1 and rank-2 scans;
  - multi-result scan lowering;
  - downstream TritonToLinalg and StructuredToMemref expectations.

  ### Test note

  Detailed BF16 promotion checks remain in `TritonArithToLinalg` tests (`bf16 -> f32`, reduction in `f32`, then truncation). The corresponding full-pipeline tests intentionally use narrower checks because their final IR also depends on later lowering stages. `masked_reduce_rank1` only makes FileCheck affine-map matching more stable.