### PR TITLE
[ci] Authenticate Triton clones with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           sudo apt-get install -y clang lld ninja-build ccache
 
       - name: Build Triton with triton-riscv
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Triton defaults to 2 * CPU count, which can exhaust memory on the
           # RISC-V runner during the C++ build.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build wheel
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           ./scripts/release.sh "${{ steps.vars.outputs.py_tag }}" "${{ matrix.target_arch }}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,17 +43,22 @@ esac
 LLVM_URL="${TRITON_LLVM_PACKAGE_URL:-${LLVM_DEFAULT_URL}}"
 BUDDY_URL="${TRITON_BUDDY_PACKAGE_URL:-${BUDDY_DEFAULT_URL}}"
 
+# Keep the token out of the repository's remote URL while authenticating CI
+# clones and fetches. Without a token, Git remains usable for local builds.
+GIT_AUTH_ARGS=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    GIT_AUTH_HEADER="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 | tr -d '\n')"
+    GIT_AUTH_ARGS=(-c "http.extraHeader=AUTHORIZATION: basic ${GIT_AUTH_HEADER}")
+fi
+
 if [ ! -d "${TRITON_DIR}" ]; then
-    git clone https://github.com/triton-lang/triton.git "${TRITON_DIR}"
+    git "${GIT_AUTH_ARGS[@]}" clone https://github.com/triton-lang/triton.git "${TRITON_DIR}"
 fi
 
 git config --global --add safe.directory "${TRITON_RISCV_DIR}"
 git config --global --add safe.directory "${TRITON_DIR}"
 if ! git -C "${TRITON_DIR}" cat-file -e "${TRITON_HASH}^{commit}" 2>/dev/null; then
-    git -C "${TRITON_DIR}" fetch origin
-fi
-if ! git -C "${TRITON_DIR}" cat-file -e "${TRITON_HASH}^{commit}" 2>/dev/null; then
-    git -C "${TRITON_DIR}" fetch origin "${TRITON_HASH}"
+    git "${GIT_AUTH_ARGS[@]}" -C "${TRITON_DIR}" fetch origin "${TRITON_HASH}"
 fi
 git -C "${TRITON_DIR}" reset --hard "${TRITON_HASH}"
 
@@ -61,21 +66,23 @@ git -C "${TRITON_DIR}" reset --hard "${TRITON_HASH}"
 
 mkdir -p "${TOOLCHAIN_DIR}"
 
-if [ ! -d "${LLVM_BINARY_DIR}" ]; then
-    rm -rf "${LLVM_EXTRACT_DIR}"
-    mkdir -p "${LLVM_EXTRACT_DIR}"
-    curl -fL "${LLVM_URL}" -o "${TOOLCHAIN_DIR}/llvm.tar.gz"
-    tar -xzf "${TOOLCHAIN_DIR}/llvm.tar.gz" -C "${LLVM_EXTRACT_DIR}"
-    rm -f "${TOOLCHAIN_DIR}/llvm.tar.gz"
-fi
+download_package() {
+    local binary_dir="$1"
+    local extract_dir="$2"
+    local url="$3"
+    local archive="$4"
 
-if [ ! -d "${BUDDY_MLIR_BINARY_DIR}" ]; then
-    rm -rf "${BUDDY_EXTRACT_DIR}"
-    mkdir -p "${BUDDY_EXTRACT_DIR}"
-    curl -fL "${BUDDY_URL}" -o "${TOOLCHAIN_DIR}/buddy.tar.gz"
-    tar -xzf "${TOOLCHAIN_DIR}/buddy.tar.gz" -C "${BUDDY_EXTRACT_DIR}"
-    rm -f "${TOOLCHAIN_DIR}/buddy.tar.gz"
-fi
+    if [ ! -d "${binary_dir}" ]; then
+        rm -rf "${extract_dir}"
+        mkdir -p "${extract_dir}"
+        curl -fL "${url}" -o "${TOOLCHAIN_DIR}/${archive}"
+        tar -xzf "${TOOLCHAIN_DIR}/${archive}" -C "${extract_dir}"
+        rm -f "${TOOLCHAIN_DIR}/${archive}"
+    fi
+}
+
+download_package "${LLVM_BINARY_DIR}" "${LLVM_EXTRACT_DIR}" "${LLVM_URL}" llvm.tar.gz
+download_package "${BUDDY_MLIR_BINARY_DIR}" "${BUDDY_EXTRACT_DIR}" "${BUDDY_URL}" buddy.tar.gz
 
 [ -d "${LLVM_BINARY_DIR}" ]
 [ -d "${BUDDY_MLIR_BINARY_DIR}" ]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -64,6 +64,9 @@ if [ -z "${IN_DOCKER:-}" ]; then
             DOCKER_ENV_ARGS+=(-e "${proxy_var}=${!proxy_var}")
         fi
     done
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        DOCKER_ENV_ARGS+=(-e GITHUB_TOKEN)
+    fi
 
     docker "${DOCKER_RUN_ARGS[@]}" \
         "${DOCKER_ENV_ARGS[@]}" \


### PR DESCRIPTION
## 变更说明 / Summary

修复了 CI clone triton 报错, 现在 ci 直接使用 git clone 拉取 triton 代码仓库, 但是因为没有传入 ghthub_token 会被限速, 导致 clone 失败, 这个 PR 在 git clone 命令多传入了相关的 http header 参数

后续应该切换为 checkout action 自动解决相关问题, 不过也要同时更新 renovate bot 配置

## 验证方式 / Validation

直接查看 ci 情况

## 检查清单 / Checklist

- [ ] The change is focused and contains no unrelated modifications.
- [ ] I have followed the target repository's contribution guidelines.
- [ ] I have added or updated tests where applicable.
- [ ] I have updated related documentation where applicable.
- [ ] I have run the relevant formatting, lint, build, and test checks.
- [ ] I have described known limitations or compatibility impact.
